### PR TITLE
Correct config attribute name in docs

### DIFF
--- a/doc/howto/config.rst
+++ b/doc/howto/config.rst
@@ -230,8 +230,8 @@ There are two options common to all services: 'name' and 'endpoints'.
 The remaining options are specific to one or the other of the service types.
 Which one is specified along side the name of the option
 
-timeslack
-^^^^^^^^^
+accepted_time_diff
+^^^^^^^^^^^^^^^^^^
 
 If your computer and another computer that you are communicating with are not
 in synch regarding the computer clock. Then you here can state how big a


### PR DESCRIPTION
It may make more sense to fix the relevant code to use the `timeslack` attribute. For example, here:
https://github.com/rohe/pysaml2/blob/bb2b49089e85762e0ddaf2026a883be3ac838e82/src/saml2/response.py#L70
