### PR TITLE
pypi page contains incorrect project name and a link to a now defunct launchpad page

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@ README for PySAML2
 
 Dependencies
 ------------
-Pylint should be compatible with any python >= 2.6 not 3.X yet.
+PySAML2 should be compatible with any python >= 2.6 not 3.X yet.
 To be able to sign/verify, encrypt/decrypt you need xmlsec1.
 The repoze stuff works best together with repoze.who .
 
@@ -39,7 +39,7 @@ Comments, support, bug reports
 
 Project page on : 
 
-https://code.launchpad.net/~roland-hedberg/pysaml2/main
+https://github.com/rohe/pysaml2
 
 Use the Pysaml2@uma.es mailing list. Since we do not have
 publicly available bug tracker yet, bug reports should be emailed

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ PySAML2 - SAML2 in Python
 *************************
 
 :Author: Roland Hedberg
-:Version: 0.3
+:Version: 1.0.0
 
 PySAML2 is a pure python implementation of a SAML2 service provider and to
 some extend also the identity provider. Originally written to work in a WSGI


### PR DESCRIPTION
Thanks for creating and maintaining pysaml2 by the way. Hope I'll be able to help more in the future.
