### PR TITLE
Add support for raw xml metadata in the config dict

### DIFF
--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -263,6 +263,11 @@ class Config(object):
         if "local" in metadata_conf:
             for mdfile in metadata_conf["local"]:
                 metad.import_metadata(open(mdfile).read(), mdfile)
+        if "inline" in metadata_conf:
+            index = 1
+            for md in metadata_conf["inline"]:
+                metad.import_metadata(md, "inline_xml.%d" % index)
+                index += 1
         if "remote" in metadata_conf:
             for spec in metadata_conf["remote"]:
                 try:


### PR DESCRIPTION
In my project the IdP metadata is read from the database, and it'd be a  hassle to create a file on disk just for the sake of loading it back to memory.
It is likely not hard at all to just call import_metadata directly, so this api change wouldn't be necessary.

However, supporting "inline" array seems like a much simpler approach.
