### PR TITLE
Prepare signature for authn request. Verify signature for ecp.

### DIFF
--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -210,7 +210,7 @@ class Base(Entity):
                              nameid_format=NAMEID_FORMAT_TRANSIENT,
                              service_url_binding=None, message_id=0,
                              consent=None, extensions=None, sign=None,
-                             allow_create=False, **kwargs):
+                             allow_create=False, sign_prepare=False, **kwargs):
         """ Creates an authentication request.
         
         :param destination: Where the request should be sent.
@@ -224,6 +224,7 @@ class Base(Entity):
         :param consent: Whether the principal have given her consent
         :param extensions: Possible extensions
         :param sign: Whether the request should be signed or not.
+        :param sign_prepare: Whether the signature should be prepared or not.
         :param allow_create: If the identity provider is allowed, in the course
             of fulfilling the request, to create a new identifier to represent
             the principal.
@@ -293,7 +294,7 @@ class Base(Entity):
             pass
 
         return self._message(AuthnRequest, destination, message_id, consent,
-                             extensions, sign,
+                             extensions, sign, sign_prepare,
                              protocol_binding=binding,
                              scoping=scoping, **args)
 

--- a/src/saml2/httpbase.py
+++ b/src/saml2/httpbase.py
@@ -304,7 +304,7 @@ class HTTPBase(object):
 
         if sign and self.sec:
             _signed = self.sec.sign_statement_using_xmlsec(
-                soap_message, class_name=class_name(request), nodeid=request.id)
+                soap_message, class_name=class_name(request), node_id=request.id)
             soap_message = _signed
 
         return {"url": destination, "method": "POST",

--- a/src/saml2/request.py
+++ b/src/saml2/request.py
@@ -36,12 +36,12 @@ class Request(object):
         self.message = None
         self.not_on_or_after = 0
 
-    def _loads(self, xmldata, binding=None):
+    def _loads(self, xmldata, binding=None, origdoc=None):
         # own copy
         self.xmlstr = xmldata[:]
         logger.info("xmlstr: %s" % (self.xmlstr,))
         try:
-            self.message = self.signature_check(xmldata)
+            self.message = self.signature_check(xmldata, origdoc=origdoc)
         except TypeError:
             raise
         except Exception, excp:
@@ -84,8 +84,8 @@ class Request(object):
         assert self.issue_instant_ok()
         return self
 
-    def loads(self, xmldata, binding):
-        return self._loads(xmldata, binding)
+    def loads(self, xmldata, binding, origdoc=None):
+        return self._loads(xmldata, binding, origdoc)
 
     def verify(self):
         try:


### PR DESCRIPTION
Added functionality to prepare signature for a authn request, without
signing. This makes it possible to sign the authn request within a SOAP
message instead. To verify a authn request in a ecp it have to validate
the whole SOAP message and not just the authn request. Added logic to
sen the original xml document to the validation function.
