### PR TITLE
decrypt() expects a string not an xmlenc.EncrypedData

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -685,7 +685,7 @@ class AuthnResponse(StatusResponse):
     
     def _encrypted_assertion(self, xmlstr):
         if xmlstr.encrypted_data:
-            assertion_str = self.sec.decrypt(xmlstr.encrypted_data)
+            assertion_str = self.sec.decrypt(xmlstr.encrypted_data.to_string())
             assertion = saml.assertion_from_string(assertion_str)
         else:
             decrypt_xml = self.sec.decrypt(xmlstr)


### PR DESCRIPTION
saml2.sigver.decrypt() raises:

```
TypeError: object of type 'EncryptedData' has no len()
```
