### PR TITLE
Do not validate xmlsec output for encrypt/decrypt, these operations generate no output.

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -663,7 +663,8 @@ class CryptoBackendXmlSec1(CryptoBackend):
                     ]
 
         (_stdout, _stderr, output) = self._run_xmlsec(com_list, [template],
-                                                      exception=DecryptError)
+                                                      exception=DecryptError,
+                                                      validate_output=False)
         return output
 
     def decrypt(self, enctext, key_file):
@@ -675,7 +676,8 @@ class CryptoBackendXmlSec1(CryptoBackend):
                     ]
 
         (_stdout, _stderr, output) = self._run_xmlsec(com_list, [fil],
-                                                      exception=DecryptError)
+                                                      exception=DecryptError,
+                                                      validate_output=False)
         return output
 
     def sign_statement(self, statement, class_name, key, key_file, node_id,


### PR DESCRIPTION
Decrypting an encrypted response message with xmlsec generates no output and so this is treated as a failure.

e.g. this command produces no output even though it succeeds in decrypting the XML:
    /usr/bin/xmlsec1 --decrypt --privkey-pem ~/saml.key --id-attr:ID EncryptedKey --output /tmp/dec.xml saml-response-encrypted.xml

So we pass validate_output=False to the encrypt and decrypt operations.
