### PR TITLE
Fixed XML parse error when loading raw metadata with 'inline' parameter.

### DIFF
--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -428,7 +428,7 @@ class MetadataStore(object):
         elif typ == "inline":
             self.ii += 1
             key = self.ii
-            md = MetaData(self.onts, self.attrc)
+            md = MetaData(self.onts, self.attrc, args[0])
         elif typ == "remote":
             key = kwargs["url"]
             md = MetaDataExtern(self.onts, self.attrc,


### PR DESCRIPTION
An error occurs in MetaData.load() because the value of self.metadata is empty string.
By applying the patch it works well.

Or I wonder if my configuration is not right.
The following is part of dict for sp_config.

``` python

    'metadata': {
        'inline': ['<?xml version="1.0"?>......'],
    },
```
