### PR TITLE
bugs in entity.py for signed responses

### DIFF
--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -339,7 +339,7 @@ class Entity(HTTPBase):
             mid = msg.id
 
         try:
-            to_sign.append([(class_name(msg), mid)])
+            to_sign += [(class_name(msg), mid)]
         except AttributeError:
             to_sign = [(class_name(msg), mid)]
 


### PR DESCRIPTION
Hi, I'm using pysaml2 to generate assertions to test an SP and found these when generating signed authn responses.
