### PR TITLE
Fix KeyError when signing http_redirect_message

### DIFF
--- a/src/saml2/pack.py
+++ b/src/saml2/pack.py
@@ -135,7 +135,7 @@ def http_redirect_message(message, location, relay_state="", typ="SAMLRequest",
 
         if sigalg == RSA_SHA1:
             signer = RSASigner(sha1_digest, "sha1")
-            string = "&".join([urllib.urlencode({k: args[k]}) for k in _order])
+            string = "&".join([urllib.urlencode({k: args[k]}) for k in _order if k in args])
             args["Signature"] = base64.b64encode(signer.sign(string, key))
             string = urllib.urlencode(args)
         else:


### PR DESCRIPTION
Without this change I get the following traceback:

> > > pack.http_redirect_message(req.to_string(), destination, sigalg=pack.RSA_SHA1, key=rsa)
> > > Traceback (most recent call last):
> > >   File "<redacted>", line 1, in <module>
> > >   File "<redacted>\pysaml2-1.0.3-py2.7.egg\saml2\pack.py", line 138, in http_redirect_message
> > >     string = "&".join([urllib.urlencode({k: args[k]}) for k in _order])
> > > KeyError: 'RelayState'
