### PR TITLE
Removed errenous comma sign

### DIFF
--- a/src/saml2/assertion.py
+++ b/src/saml2/assertion.py
@@ -697,7 +697,7 @@ class Assertion(dict):
             _ass.authn_statement = [_authn_statement]
 
         if not attr_statement.empty():
-            _ass.attribute_statement=[attr_statement],
+            _ass.attribute_statement=[attr_statement]
 
         return _ass
     


### PR DESCRIPTION
This resolves this issue with the mongodb backend store:
InvalidDocument: Cannot encode object: <saml2.saml.AttributeStatement object at 0x28a2d90>
