### PR TITLE
IDP logout fix, add .gitignore, and more....

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,9 @@
+idp/idp_conf.py
+idp2/idp.subject
+idp2/idp_conf.py
+sp/outstanding
+sp/sp_conf.py
+server.crt
+server.csr
+server.key
+server.key.org

--- a/example/idp2/static/css/main.css
+++ b/example/idp2/static/css/main.css
@@ -1,0 +1,2 @@
+/* Sample css file */
+

--- a/example/idp2/templates/root.mako
+++ b/example/idp2/templates/root.mako
@@ -6,7 +6,7 @@
     <% self.seen_css.add(path) %>
 </%def>
 <%def name="css()" filter="trim">
-    ${css_link('/css/main.css', 'screen')}
+    ${css_link('/static/css/main.css', 'screen')}
 </%def>
 <%def name="pre()" filter="trim">
     <div class="header">

--- a/example/sp/sp.py
+++ b/example/sp/sp.py
@@ -270,6 +270,9 @@ app_with_auth = make_middleware_with_config(application, {"here": "."},
 # ----------------------------------------------------------------------------
 PORT = 8087
 
+# allow uwsgi or gunicorn mount
+# by moving some initialization out of __name__ == '__main__' section.
+# uwsgi -s 0.0.0.0:8087 --protocol http --callable app_with_auth --module idp
 
 if __name__ == '__main__':
     #make_metadata arguments


### PR DESCRIPTION
Make IDP logout a little more resilient by double checking content in the cache.
Added some .gitignore for generated and copied files in idp, sp and idp2 folders.
Allow both sp and idp2 to be mounted using wsgi container.
Add static handler for css and other files in idp2.
