### PR TITLE
want_assertions_signed and authn_requests_signed are boolean

### DIFF
--- a/src/saml2/metadata.py
+++ b/src/saml2/metadata.py
@@ -474,7 +474,7 @@ def do_spsso_descriptor(conf, cert=None):
             if val is None:
                 setattr(spsso, key, DEFAULT[key])  # default ?!
             else:
-                strval = "{0:>s}".format(val)
+                strval = "{0:>s}".format(str(val))
                 setattr(spsso, key, strval.lower())
         except KeyError:
             setattr(spsso, key, DEFAULTS[key])


### PR DESCRIPTION
If I have a config that specifies want_assertions_signed or authn_requests_signed for a sp service, generating the metadata xml fails.  It correctly populates the defaults if I don't specify want_assertions_signed or authn_requests_signed in the config.   If I do specify either option, the code fails because the code is expecting a string instead of a bool.

```
CONFIG = {
  ...
            "service": {
                "sp": {
                    "name": "Example",
                    "endpoints": {
                        "assertion_consumer_service": ['https://www.example.com/account/saml/assertion'],
                    },
                    "required_attributes": ["sn", "givenName", "eduPersonPrincipalName"],
                    "want_assertions_signed": True,
                    "authn_requests_signed": False,
                }
            },
  ...
}
```
