### PR TITLE
Fix error looking at empty post in sp plugin.

### DIFF
--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -508,6 +508,8 @@ class SAML2Plugin(object):
             binding = BINDING_HTTP_REDIRECT
         else:
             post = self._get_post(environ)
+            if post.list is None:
+                post.list = []
             binding = BINDING_HTTP_POST
 
         try:


### PR DESCRIPTION
When using POST and PUT on a site using pysaml2 there is an error when posting JSON or other non-parseable content since the s2repoze plugin always assumes that post has a list of items. This is a tiny hack to create an empty list in the post to make sure that the "in port" operation doesn't cause an exception.
