### PR TITLE
Fixed set_cookie max-age parsing

### DIFF
--- a/src/saml2/httpbase.py
+++ b/src/saml2/httpbase.py
@@ -177,7 +177,7 @@ class HTTPBase(object):
                             std_attr[attr] = morsel[attr]
                 elif attr == "max-age":
                     if morsel["max-age"]:
-                        std_attr["expires"] = _since_epoch(morsel["max-age"])
+                        std_attr["expires"] = time.time() + int(morsel["max-age"])
 
             for att, item in PAIRS.items():
                 if std_attr[att]:


### PR DESCRIPTION
Max-age is expected to be in seconds and thus cannot be parsed by _since_epoch.
Expire attribute is calculated from now() and max-age
