### PR TITLE
Allow usage of external IdentDB instance

### DIFF
--- a/src/saml2/server.py
+++ b/src/saml2/server.py
@@ -21,6 +21,7 @@ or attribute authority (AA) may use to conclude its tasks.
 import logging
 import os
 
+import importlib
 import shelve
 import threading
 
@@ -144,7 +145,12 @@ class Server(Entity):
 
                 self.ident = IdentMDB(database=addr, collection="ident")
 
-        if typ == "mongodb":
+            elif typ == "identdb":
+                mod, clas = addr.rsplit('.', 1)
+                mod = importlib.import_module(mod)
+                self.ident = getattr(mod, clas)()
+
+        if typ == "mongodb" or typ == "identdb":
             pass
         elif idb is not None:
             self.ident = IdentDB(idb)


### PR DESCRIPTION
Server can be configured to use external IdentDB instance
The configuration has to be a tuple with following syntax:
('identdb', 'module.class')

This allows to use custom databases by creating a derived class from IdentDB
