### PR TITLE
Fixing location of 'allow_unknown_attributes' in args lists

### DIFF
--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -71,7 +71,8 @@ COMMON_ARGS = [
     "tmp_cert_file",
     "tmp_key_file",
     "validate_certificate",
-    "extensions"
+    "extensions",
+    "allow_unknown_attributes"
 ]
 
 SP_ARGS = [
@@ -90,7 +91,6 @@ SP_ARGS = [
     "allow_unsolicited",
     "ecp",
     "name_id_format",
-    "allow_unknown_attributes"
 ]
 
 AA_IDP_ARGS = [


### PR DESCRIPTION
Based on how it's used in https://github.com/Runscope/pysaml2/blob/master/src/saml2/client_base.py#L537 it needs to be in the `COMMON_ARGS` list, not in the `SP_ARGS` list as it currently is.
