### PR TITLE
Fix for POST requests failing with 500

### DIFF
--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -58,21 +58,6 @@ def construct_came_from(environ):
         came_from += '?' + qstr
     return came_from
 
-
-def cgi_field_storage_to_dict(field_storage):
-    """Get a plain dictionary, rather than the '.value' system used by the
-    cgi module."""
-
-    params = {}
-    for key in field_storage.keys():
-        try:
-            params[key] = field_storage[key].value
-        except AttributeError:
-            if isinstance(field_storage[key], basestring):
-                params[key] = field_storage[key]
-
-    return params
-
 def exception_trace(tag, exc, log):
     message = traceback.format_exception(*sys.exc_info())
     log.error("[%s] ExcList: %s" % (tag, "".join(message),))
@@ -530,7 +515,7 @@ class SAML2Plugin(object):
                             return {}
                     else:
                         session_info = self._eval_authn_response(
-                            environ, cgi_field_storage_to_dict(post),
+                            environ, post,
                             binding=binding)
                 except Exception, err:
                     environ["s2repoze.saml_error"] = err


### PR DESCRIPTION
There seems to be a problem with the _get_post() method in the SAML2Plugin for repoze.who. When used with pyramid and repoze.who, all POST requests fail with code 500 as soon as pysaml2 is set as a repoze.who identifier plugin. This is because at the time pyramid is reading the environ dict, CONTENT_LENGTH is set to the size of the POST request, but environ[wsgi.input] is empty. My guess is that the restoring of environ['wsgi.input'] via

```
environ['wsgi.input'] = StringIO(body)
```

is ineffective because environ['wsgi.input'] is emptied/read again afterwards by cgi.FieldStorage().

I replaced _get_post() with a simplier method using parse_qs to get a dict of the POST parameters and removed the now unneeded cgi_field_storage method. environ['wsgi.input'] is restored immediately after reading it and is never touched again.
