### PR TITLE
use NAME_FORMAT_URI as default fallback nameFormat in AttributeType_

### DIFF
--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -1040,7 +1040,7 @@ class AttributeType_(SamlBase):
     def __init__(self,
                  attribute_value=None,
                  name=None,
-                 name_format=None,
+                 name_format=NAME_FORMAT_URI,
                  friendly_name=None,
                  text=None,
                  extension_elements=None,


### PR DESCRIPTION
... for better compatibility with ADFS
