### PR TITLE
Fix looking up organization name in metadata

### DIFF
--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -758,7 +758,7 @@ class MetadataStore(object):
 
     def name(self, entity_id, langpref="en"):
         for _md in self.metadata.values():
-            if entity_id in _md.items():
+            if entity_id in _md:
                 return name(_md[entity_id], langpref)
         return None
 


### PR DESCRIPTION
This fixes a bug where pysaml2 was looking up a idp entry id incorrectly.
