### PR TITLE
Add support for travis-ci continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+
+services:
+  - mongodb
+
+install:
+  - sudo apt-get install xmlsec1
+
+script:
+  - ./setup.py test


### PR DESCRIPTION
This PR adds support for [Travis CI](https://travis-ci.org/)'s continuous integration testing service, which offers free testing for open source projects. This will run the pysaml2 tests on every commit, and email out when the tests fail. 
