### PR TITLE
pysaml2 needs at least pycrypto 2.2 for Crypto.RSA.importKey

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'paste',
     'zope.interface',
     'repoze.who',
-    'pycrypto',  # 'Crypto'
+    'pycrypto >= 2.2',  # 'Crypto'
     'pytz',
     'pyOpenSSL',
     'python-dateutil',


### PR DESCRIPTION
pysaml2 uses Crypto.RSA.importKey, which was added in pycrypto version 2.2.
