### PR TITLE
Authn_Broker fixed

### DIFF
--- a/src/saml2/authn_context/__init__.py
+++ b/src/saml2/authn_context/__init__.py
@@ -166,14 +166,20 @@ class AuthnBroker(object):
             if req_authn_context.comparison:
                 _cmp = req_authn_context.comparison
             else:
-                _cmp = "minimum"
-            return self._pick_by_class_ref(
-                req_authn_context.authn_context_class_ref[0].text, _cmp)
+                _cmp = "exact"
+            if _cmp == 'exact':
+                res = []
+                for cls_ref in req_authn_context.authn_context_class_ref:
+                    res += (self._pick_by_class_ref(cls_ref.text, _cmp))
+                return res
+            else:
+                return self._pick_by_class_ref(
+                    req_authn_context.authn_context_class_ref[0].text, _cmp)
         elif req_authn_context.authn_context_decl_ref:
             if req_authn_context.comparison:
                 _cmp = req_authn_context.comparison
             else:
-                _cmp = "minimum"
+                _cmp = "exact"
             return self._pick_by_class_ref(
                 req_authn_context.authn_context_decl_ref, _cmp)
 

--- a/tests/test_77_authn_context.py
+++ b/tests/test_77_authn_context.py
@@ -142,6 +142,24 @@ def test_authn_3():
     method, ref = info[0]
     assert REF2METHOD[AL1] == method
 
+    rac = requested_authn_context([AL1, AL2], "exact")
+
+    info = authn.pick(rac)
+    assert len(info) == 2
+    method, ref = info[0]
+    assert REF2METHOD[AL1] == method
+    method, ref = info[1]
+    assert REF2METHOD[AL2] == method
+
+    rac = requested_authn_context([AL3, AL2], "exact")
+
+    info = authn.pick(rac)
+    assert len(info) == 2
+    method, ref = info[0]
+    assert REF2METHOD[AL3] == method
+    method, ref = info[1]
+    assert REF2METHOD[AL2] == method
+
     rac = requested_authn_context(AL1, "better")
 
     info = authn.pick(rac)


### PR DESCRIPTION
Authn_Broker for comparison 'exact' should return all methods matching
from RequestedAuthnContext.
Default comparison of omitted should be 'exact'
