### PR TITLE
Allow for multiple attribute statements in response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.~
 \#*
 .*~
+*~
 *.egg-info
 example/*/*.log
 example/*.db

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='pysaml2',
-    version='2.2.1.1-rh',
+    version='2.2.1.2-rh',
     description='Python implementation of SAML Version 2 to be used in a WSGI environment',
     # long_description = read("README"),
     author='Roland Hedberg',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='pysaml2',
-    version='2.2.1beta',
+    version='2.2.1.1-rh',
     description='Python implementation of SAML Version 2 to be used in a WSGI environment',
     # long_description = read("README"),
     author='Roland Hedberg',

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -83,8 +83,8 @@ class SAML2GenericPlugin(object):
 	implements(IChallenger, IIdentifier, IAuthenticator, IMetadataProvider)
 
 	def __init__(self, rememberer_name, config, saml_client, wayf, cache,
-				 sid_store=None, sid_store_type=None, discovery="", idp_query_param="",
-				 sid_store_cert=None, sid_store_cert_type=None):
+				 sid_store=None, sid_store_type='local', discovery="", idp_query_param="",
+				 sid_store_cert=None, sid_store_cert_type='local'):
 		self.rememberer_name = rememberer_name
 		self.wayf = wayf
 		self.saml_client = saml_client

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -136,6 +136,16 @@ class SAML2GenericPlugin(object):
 		else:
 			self._get_outstanding_queries()[key] = value
 
+	def _delete_outstanding_query(self, key):
+		logger.debug('sid_store_type: {0}'.format(self.sid_store_type))
+		if self.sid_store_type == 'memcache':
+			queries = self._get_outstanding_queries()
+			queries.pop(key, None)
+			self.outstanding_query_store.set(QUERY_STORE_KEY, queries)
+		else:
+			self._get_outstanding_queries().pop(key, None)
+
+
 	def _get_outstanding_certs(self):
 		if self.sid_store_type == 'memcache':
 			return self.outstanding_cert_store.get(CERT_STORE_KEY) or {}
@@ -455,6 +465,8 @@ class SAML2GenericPlugin(object):
 		except TypeError, excp:
 			return None
 
+		logger.debug('auth response: {0}'.format(authresp))
+		logger.debug('Session Info: {0}'.format(session_info))
 		if session_info["came_from"]:
 			try:
 				path, query = session_info["came_from"].split('?')

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -134,7 +134,7 @@ class SAML2GenericPlugin(object):
 			queries = outstanding_query_store.get(QUERY_STORE_KEY)
 			queries[key] = value
 			outstanding_query_store.set(QUERY_STORE_KEY, queries)
-		else
+		else:
 			outstanding_query_store[key] = value
 
 	def _get_outstanding_certs(self):
@@ -154,7 +154,7 @@ class SAML2GenericPlugin(object):
 			certs = outstanding_cert_store.get(CERT_STORE_KEY)
 			certs[key] = value
 			outstanding_cert_store.set(CERT_STORE_KEY, certs)
-		else
+		else:
 			outstanding_cert_store[key] = value
 
 	def _get_rememberer(self, request):

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -125,6 +125,7 @@ class SAML2GenericPlugin(object):
 
 	#### IIdentifier ####
 	def remember(self, environ, identity, **kw):
+		logger.debug('saml - remember')
 		rememberer = self._get_rememberer(environ)
 		if not rememberer:
 			return []

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -120,23 +120,20 @@ class SAML2GenericPlugin(object):
 
 	def _get_outstanding_queries(self):
 		if self.sid_store_type == 'memcache':
-			return self.outstanding_query_store.get(QUERY_STORE_KEY)
+			return self.outstanding_query_store.get(QUERY_STORE_KEY, {})
 
 		return self.outstanding_query_store
 
 	def _get_outstanding_query(self, key):
-		if self.sid_store_type == 'memcache':
-			return self.outstanding_query_store.get(QUERY_STORE_KEY).get(key)
-
-		return self.outstanding_query_store.get(key)
+		return self._get_outstanding_queries.get(key)
 
 	def _set_outstanding_query(self, key, value):
 		if self.sid_store_type == 'memcache':
-			queries = self.outstanding_query_store.get(QUERY_STORE_KEY)
+			queries = self._get_outstanding_queries()
 			queries[key] = value
 			self.outstanding_query_store.set(QUERY_STORE_KEY, queries)
 		else:
-			self.outstanding_query_store[key] = value
+			self._get_outstanding_queries()[key] = value
 
 	def _get_outstanding_certs(self):
 		if self.sid_store_type == 'memcache':
@@ -145,18 +142,15 @@ class SAML2GenericPlugin(object):
 		return self.outstanding_cert_store
 
 	def _get_outstanding_cert(self, key):
-		if self.sid_store_type == 'memcache':
-			return outstanding_cert_store.get(CERT_STORE_KEY).get(key)
-
-		return self.outstanding_cert_store.get(key)
+		return self._get_outstanding_certs.get(key)
 
 	def _set_outstanding_cert(self, key, value):
 		if self.sid_store_type == 'memcache':
-			certs = self.outstanding_cert_store.get(CERT_STORE_KEY)
+			certs = self._get_outstanding_certs()
 			certs[key] = value
 			self.outstanding_cert_store.set(CERT_STORE_KEY, certs)
 		else:
-			self.outstanding_cert_store[key] = value
+			self._get_outstanding_certs()[key] = value
 
 	def _get_rememberer(self, request):
 		api = request.get('repoze.who.api', None)

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -421,11 +421,11 @@ class SAML2GenericPlugin(object):
 						environ["PATH_INFO"])[1] == "":
 					query = parse_qs(environ["QUERY_STRING"])
 					sid = query["sid"][0]
-					self._get_outstanding_query(sid_)
+					came_from = self._get_outstanding_query(sid)
 			except:
 				pass
 			# remember the request
-			self._set_outstanding_query(sid_, came_from)
+			self._set_outstanding_query(_sid, came_from)
 
 			if not ht_args["data"] and ht_args["headers"][0][0] == "Location":
 				return HTTPSeeOther(headers=ht_args["headers"])

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -11,6 +11,7 @@ import sys
 import platform
 import shelve
 import traceback
+import memcache
 import saml2
 from urlparse import parse_qs, urlparse
 from saml2.md import Extensions
@@ -118,44 +119,44 @@ class SAML2GenericPlugin(object):
 		self.iam = platform.node()
 
 	def _get_outstanding_queries(self):
-		if sid_store_type == 'memcache':
-			return outstanding_query_store.get(QUERY_STORE_KEY)
+		if self.sid_store_type == 'memcache':
+			return self.outstanding_query_store.get(QUERY_STORE_KEY)
 
-		return outstanding_query_store
+		return self.outstanding_query_store
 
 	def _get_outstanding_query(self, key):
-		if sid_store_type == 'memcache':
-			return outstanding_query_store.get(QUERY_STORE_KEY).get(key)
+		if self.sid_store_type == 'memcache':
+			return self.outstanding_query_store.get(QUERY_STORE_KEY).get(key)
 
-		return outstanding_query_store.get(key)
+		return self.outstanding_query_store.get(key)
 
 	def _set_outstanding_query(self, key, value):
-		if sid_store_type == 'memcache':
-			queries = outstanding_query_store.get(QUERY_STORE_KEY)
+		if self.sid_store_type == 'memcache':
+			queries = self.outstanding_query_store.get(QUERY_STORE_KEY)
 			queries[key] = value
-			outstanding_query_store.set(QUERY_STORE_KEY, queries)
+			self.outstanding_query_store.set(QUERY_STORE_KEY, queries)
 		else:
-			outstanding_query_store[key] = value
+			self.outstanding_query_store[key] = value
 
 	def _get_outstanding_certs(self):
-		if sid_store_type == 'memcache':
-			return outstanding_cert_store.get(CERT_STORE_KEY)
+		if self.sid_store_type == 'memcache':
+			return self.outstanding_cert_store.get(CERT_STORE_KEY)
 
-		return outstanding_cert_store
+		return self.outstanding_cert_store
 
 	def _get_outstanding_cert(self, key):
-		if sid_store_type == 'memcache':
+		if self.sid_store_type == 'memcache':
 			return outstanding_cert_store.get(CERT_STORE_KEY).get(key)
 
-		return outstanding_cert_store.get(key)
+		return self.outstanding_cert_store.get(key)
 
 	def _set_outstanding_cert(self, key, value):
-		if sid_store_type == 'memcache':
-			certs = outstanding_cert_store.get(CERT_STORE_KEY)
+		if self.sid_store_type == 'memcache':
+			certs = self.outstanding_cert_store.get(CERT_STORE_KEY)
 			certs[key] = value
-			outstanding_cert_store.set(CERT_STORE_KEY, certs)
+			self.outstanding_cert_store.set(CERT_STORE_KEY, certs)
 		else:
-			outstanding_cert_store[key] = value
+			self.outstanding_cert_store[key] = value
 
 	def _get_rememberer(self, request):
 		api = request.get('repoze.who.api', None)

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -128,7 +128,7 @@ class SAML2GenericPlugin(object):
 		return self._get_outstanding_queries.get(key)
 
 	def _set_outstanding_query(self, key, value):
-		logger.debug('sid_store_type: {0}'.format(sid_store_type))
+		logger.debug('sid_store_type: {0}'.format(self.sid_store_type))
 		if self.sid_store_type == 'memcache':
 			queries = self._get_outstanding_queries()
 			queries[key] = value

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -125,8 +125,13 @@ class SAML2GenericPlugin(object):
 
 	#### IIdentifier ####
 	def remember(self, environ, identity, **kw):
-		logger.debug("remember -- IDENTITY: {0}".format(identity))
-		logger.debug("remember -- ENVIRON: {0}".format(environ))
+		logger.debug("remember -- IDENTITY.repoze.who.userid: {0}".format(identity.get('repoze.who.userid')))
+		logger.debug("remember -- IDENTITY.tokens: {0}".format(identity.get('tokens', ())))
+		logger.debug("remember -- IDENTITY.userdata: {0}".format(identity.get('userdata', {})))
+		logger.debug("remember -- IDENTITY.user: {0}".format(identity.get('user', {})))
+		logger.debug("remember -- IDENTITY.max_age: {0}".format(identity.get('max_age', None)))
+		logger.debug("remember -- IDENTITY.login: {0}".format(identity.get('login', 'NOLOGIN')))
+		
 		rememberer = self._get_rememberer(environ)
 		if not rememberer:
 			return []

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -78,7 +78,7 @@ class ECP_response(object):
 		return [self.content]
 
 
-class SAML2Plugin(object):
+class SAML2GenericPlugin(object):
 	implements(IChallenger, IIdentifier, IAuthenticator, IMetadataProvider)
 
 	def __init__(self, rememberer_name, config, saml_client, wayf, cache,
@@ -275,6 +275,7 @@ class SAML2Plugin(object):
 	def challenge(self, environ, _status, _app_headers, _forget_headers):
 		_cli = self.saml_client
 
+		#TODO: change to remote_user_key env variable
 		if 'REMOTE_USER' in environ:
 			name_id = decode(environ["REMOTE_USER"])
 
@@ -630,6 +631,6 @@ def make_plugin(remember_name=None,  # plugin for remember
 	scl = Saml2Client(config=conf, identity_cache=identity_cache,
 					  virtual_organization=virtual_organization)
 
-	plugin = SAML2Plugin(remember_name, conf, scl, wayf, cache, sid_store,
-						 discovery, idp_query_param)
+	plugin = SAML2GenericPlugin(remember_name, conf, scl, wayf, cache, sid_store,
+						 		discovery, idp_query_param)
 	return plugin

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -125,11 +125,14 @@ class SAML2GenericPlugin(object):
 
 	#### IIdentifier ####
 	def remember(self, environ, identity, **kw):
-		logger.debug('saml - remember')
-		rememberer = self._get_rememberer(environ)
-		if not rememberer:
-			return []
-		return rememberer.remember(environ, identity)
+		#pcrownov: Commenting out since pyramid_whoauth calls each rememberer plugin causing real one to
+		#			be called multiple times
+		#logger.debug('saml - remember')
+		#rememberer = self._get_rememberer(environ)
+		#if not rememberer:
+		#	return []
+		#return rememberer.remember(environ, identity)
+		return []
 
 
 	#### IIdentifier ####

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -172,6 +172,7 @@ class SAML2GenericPlugin(object):
 	def _get_rememberer(self, request):
 		api = request.get('repoze.who.api', None)
 		if not api:
+			logger.error("_get_rememberer -- Error getting rememberer from requests, none exists: {0}".format(request))
 			return None
 		api_identifiers = api.identifiers
 		rememberer = None

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -125,13 +125,6 @@ class SAML2GenericPlugin(object):
 
 	#### IIdentifier ####
 	def remember(self, environ, identity, **kw):
-		logger.debug("remember -- IDENTITY.repoze.who.userid: {0}".format(identity.get('repoze.who.userid')))
-		logger.debug("remember -- IDENTITY.tokens: {0}".format(identity.get('tokens', ())))
-		logger.debug("remember -- IDENTITY.userdata: {0}".format(identity.get('userdata', {})))
-		logger.debug("remember -- IDENTITY.user: {0}".format(identity.get('user', {})))
-		logger.debug("remember -- IDENTITY.max_age: {0}".format(identity.get('max_age', None)))
-		logger.debug("remember -- IDENTITY.login: {0}".format(identity.get('login', 'NOLOGIN')))
-		
 		rememberer = self._get_rememberer(environ)
 		if not rememberer:
 			return []
@@ -392,7 +385,7 @@ class SAML2GenericPlugin(object):
 			"login": cni,
 			"password": "",
 			'repoze.who.userid': cni,
-			"user": session_info["ava"],
+			"userdata": session_info["ava"],
 		}
 
 		return identity
@@ -548,9 +541,9 @@ class SAML2GenericPlugin(object):
 	#noinspection PyUnusedLocal
 	def authenticate(self, environ, identity=None):
 		if identity:
-			if identity.get('user') and environ.get(
+			if identity.get('userdata') and environ.get(
 					's2repoze.sessioninfo') and identity.get(
-					'user') == environ.get('s2repoze.sessioninfo').get('ava'):
+					'userdata') == environ.get('s2repoze.sessioninfo').get('ava'):
 				return identity.get('login')
 
 			tktuser = identity.get('repoze.who.plugins.auth_tkt.userid', None)

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -1,0 +1,635 @@
+#
+"""
+A plugin that allows you to use SAML2 SSO as authentication
+and SAML2 attribute aggregations as metadata collector in your
+WSGI application.
+
+"""
+import cgi
+import logging
+import sys
+import platform
+import shelve
+import traceback
+import saml2
+from urlparse import parse_qs, urlparse
+from saml2.md import Extensions
+import xmldsig as ds
+
+from StringIO import StringIO
+
+from paste.httpexceptions import HTTPSeeOther, HTTPRedirection
+from paste.httpexceptions import HTTPNotImplemented
+from paste.httpexceptions import HTTPInternalServerError
+from paste.request import parse_dict_querystring
+from paste.request import construct_url
+from saml2.extension.pefim import SPCertEnc
+from saml2.httputil import SeeOther
+from saml2.client_base import ECP_SERVICE
+from zope.interface import implements
+
+from repoze.who.interfaces import IChallenger, IIdentifier, IAuthenticator
+from repoze.who.interfaces import IMetadataProvider
+
+from saml2 import ecp, BINDING_HTTP_REDIRECT, element_to_extension_element
+from saml2 import BINDING_HTTP_POST
+
+from saml2.client import Saml2Client
+from saml2.ident import code, decode
+from saml2.s_utils import sid
+from saml2.config import config_factory
+from saml2.profile import paos
+
+# from saml2.population import Population
+#from saml2.attribute_resolver import AttributeResolver
+
+logger = logging.getLogger(__name__)
+
+PAOS_HEADER_INFO = 'ver="%s";"%s"' % (paos.NAMESPACE, ECP_SERVICE)
+
+
+def construct_came_from(environ):
+	""" The URL that the user used when the process where interupted
+	for single-sign-on processing. """
+	came_from = environ.get("PATH_INFO")
+	qstr = environ.get("QUERY_STRING", "")
+	if qstr:
+		came_from += '?' + qstr
+	return came_from
+
+
+def exception_trace(tag, exc, log):
+	message = traceback.format_exception(*sys.exc_info())
+	logger.error("[%s] ExcList: %s" % (tag, "".join(message),))
+	logger.error("[%s] Exception: %s" % (tag, exc))
+
+
+class ECP_response(object):
+	code = 200
+	title = 'OK'
+
+	def __init__(self, content):
+		self.content = content
+
+	#noinspection PyUnusedLocal
+	def __call__(self, environ, start_response):
+		start_response('%s %s' % (self.code, self.title),
+					   [('Content-Type', "text/xml")])
+		return [self.content]
+
+
+class SAML2Plugin(object):
+	implements(IChallenger, IIdentifier, IAuthenticator, IMetadataProvider)
+
+	def __init__(self, rememberer_name, config, saml_client, wayf, cache,
+				 sid_store=None, discovery="", idp_query_param="",
+				 sid_store_cert=None, ):
+		self.rememberer_name = rememberer_name
+		self.wayf = wayf
+		self.saml_client = saml_client
+		self.conf = config
+		self.cache = cache
+		self.discosrv = discovery
+		self.idp_query_param = idp_query_param
+		self.logout_endpoints = [urlparse(ep)[2] for ep in config.endpoint(
+			"single_logout_service")]
+		try:
+			self.metadata = self.conf.metadata
+		except KeyError:
+			self.metadata = None
+		if sid_store:
+			self.outstanding_queries = shelve.open(sid_store, writeback=True)
+		else:
+			self.outstanding_queries = {}
+		if sid_store_cert:
+			self.outstanding_certs = shelve.open(sid_store_cert, writeback=True)
+		else:
+			self.outstanding_certs = {}
+
+		self.iam = platform.node()
+
+	def _get_rememberer(self, request):
+		api = request.get('repoze.who.api', None)
+		if not api:
+			return None
+		api_identifiers = api.identifiers
+		rememberer = None
+		for rememberer_set in api_identifiers:
+			if rememberer_set and rememberer_set[0] == self.rememberer_name:
+				rememberer = rememberer_set[1]
+
+		if not rememberer:
+			logger.debug("_get_rememberer -- No Remberer of name %s stored in API" % self.rememberer_name)
+
+		return rememberer
+
+	#### IIdentifier ####
+	def remember(self, environ, identity, **kw):
+		rememberer = self._get_rememberer(environ)
+		if not rememberer:
+			return []
+		return rememberer.remember(environ, identity)
+
+
+	#### IIdentifier ####
+	def forget(self, environ, identity):
+		"""Get headers to forget the identify of the given request.
+
+		This method calls the repoze.who logout() method, which in turn calls
+		the forget() method on all configured repoze.who plugins.
+		"""
+		rememberer = self._get_rememberer(environ)
+		return rememberer.forget(environ, identity)
+
+	def _get_post(self, environ):
+		"""
+		Get the posted information
+
+		:param environ: A dictionary with environment variables
+		"""
+
+		body = ''
+		try:
+			length = int(environ.get('CONTENT_LENGTH', '0'))
+		except ValueError:
+			length = 0
+		if length != 0:
+			body = environ['wsgi.input'].read(length)  # get the POST variables
+			environ[
+				's2repoze.body'] = body  # store the request body for later
+				# use by pysaml2
+			environ['wsgi.input'] = StringIO(body)  # restore the request body
+				# as a stream so that everything seems untouched
+
+		post = parse_qs(body)  # parse the POST fields into a dict
+
+		return post
+
+	def _wayf_redirect(self, came_from):
+		sid_ = sid()
+		self.outstanding_queries[sid_] = came_from
+		return -1, HTTPSeeOther(headers=[('Location',
+										  "%s?%s" % (self.wayf, sid_))])
+
+	#noinspection PyUnusedLocal
+	def _pick_idp(self, environ, came_from):
+		"""
+		If more than one idp and if none is selected, I have to do wayf or
+		disco
+		"""
+
+		# check headers to see if it's an ECP request
+		#		headers = {
+		#					'Accept' : 'text/html; application/vnd.paos+xml',
+		#					'PAOS'   : 'ver="%s";"%s"' % (paos.NAMESPACE,
+		# SERVICE)
+		#					}
+
+		_cli = self.saml_client
+
+		logger.info("_pick_idp -- [_pick_idp] Environment: %s" % environ)
+		if "HTTP_PAOS" in environ:
+			if environ["HTTP_PAOS"] == PAOS_HEADER_INFO:
+				if 'application/vnd.paos+xml' in environ["HTTP_ACCEPT"]:
+					# Where should I redirect the user to
+					# entityid -> the IdP to use
+					# relay_state -> when back from authentication
+
+					logger.info("_pick_idp -- - ECP client detected -")
+
+					_relay_state = construct_came_from(environ)
+					_entityid = _cli.config.ecp_endpoint(environ["REMOTE_ADDR"])
+
+					if not _entityid:
+						return -1, HTTPInternalServerError(
+							detail="No IdP to talk to")
+					return ecp.ecp_auth_request(_cli, _entityid,
+												_relay_state)
+				else:
+					return -1, HTTPInternalServerError(
+						detail='Faulty Accept header')
+			else:
+				return -1, HTTPInternalServerError(
+					detail='unknown ECP version')
+
+		idps = self.metadata.with_descriptor("idpsso")
+
+		idp_entity_id = query = None
+
+		for key in ['s2repoze.body', "QUERY_STRING"]:
+			query = environ.get(key)
+			if query:
+				try:
+					_idp_entity_id = dict(parse_qs(query))[
+						self.idp_query_param][0]
+					if _idp_entity_id in idps:
+						idp_entity_id = _idp_entity_id
+					break
+				except KeyError:
+					logger.debug("_pick_idp -- No IdP entity ID in query: %s" % query)
+					pass
+
+		if idp_entity_id is None:
+			if len(idps) == 1:
+				# idps is a dictionary
+				idp_entity_id = idps.keys()[0]
+			elif not len(idps):
+				return -1, HTTPInternalServerError(detail='Misconfiguration')
+			else:
+				idp_entity_id = ""
+
+				if self.wayf:
+					if query:
+						try:
+							wayf_selected = dict(parse_qs(query))[
+								"wayf_selected"][0]
+						except KeyError:
+							return self._wayf_redirect(came_from)
+						idp_entity_id = wayf_selected
+					else:
+						return self._wayf_redirect(came_from)
+				elif self.discosrv:
+					if query:
+						idp_entity_id = _cli.parse_discovery_service_response(
+							query=environ.get("QUERY_STRING"))
+					else:
+						sid_ = sid()
+						self.outstanding_queries[sid_] = came_from
+
+						eid = _cli.config.entityid
+						ret = _cli.config.getattr(
+							"endpoints", "sp")["discovery_response"][0][0]
+						ret += "?sid=%s" % sid_
+						loc = _cli.create_discovery_service_request(
+							self.discosrv, eid, **{"return": ret})
+						return -1, SeeOther(loc)
+
+				else:
+					return -1, HTTPNotImplemented(
+						detail='No WAYF or DJ present!')
+
+		return 0, idp_entity_id
+
+	#### IChallenger ####
+	#noinspection PyUnusedLocal
+	def challenge(self, environ, _status, _app_headers, _forget_headers):
+		_cli = self.saml_client
+
+		if 'REMOTE_USER' in environ:
+			name_id = decode(environ["REMOTE_USER"])
+
+			_cli = self.saml_client
+			path_info = environ['PATH_INFO']
+
+			if 'samlsp.logout' in environ:
+				responses = _cli.global_logout(name_id)
+				return self._handle_logout(responses)
+
+		if 'samlsp.pending' in environ:
+			response = environ['samlsp.pending']
+			if isinstance(response, HTTPRedirection):
+				response.headers += _forget_headers
+			return response
+
+		# Which page was accessed to get here
+		came_from = construct_came_from(environ)
+		environ["myapp.came_from"] = came_from
+
+		# Am I part of a virtual organization or more than one ?
+		try:
+			vorg_name = environ["myapp.vo"]
+		except KeyError:
+			try:
+				vorg_name = _cli.vorg._name
+			except AttributeError:
+				vorg_name = ""
+
+		# If more than one idp and if none is selected, I have to do wayf
+		(done, response) = self._pick_idp(environ, came_from)
+		# Three cases: -1 something went wrong or Discovery service used
+		#			   0 I've got an IdP to send a request to
+		#			   >0 ECP in progress
+		if done == -1:
+			return response
+		elif done > 0:
+			self.outstanding_queries[done] = came_from
+			return ECP_response(response)
+		else:
+			entity_id = response
+			# Do the AuthnRequest
+			_binding = BINDING_HTTP_REDIRECT
+			try:
+				srvs = _cli.metadata.single_sign_on_service(entity_id, _binding)
+				dest = srvs[0]["location"]
+
+				extensions = None
+				cert = None
+
+				if _cli.config.generate_cert_func is not None:
+					cert_str, req_key_str = _cli.config.generate_cert_func()
+					cert = {
+						"cert": cert_str,
+						"key": req_key_str
+					}
+					spcertenc = SPCertEnc(x509_data=ds.X509Data(
+						x509_certificate=ds.X509Certificate(text=cert_str)))
+					extensions = Extensions(extension_elements=[
+						element_to_extension_element(spcertenc)])
+
+				if _cli.authn_requests_signed:
+					_sid = saml2.s_utils.sid(_cli.seed)
+					req_id, msg_str = _cli.create_authn_request(
+						dest, vorg=vorg_name, sign=_cli.authn_requests_signed,
+						message_id=_sid, extensions=extensions)
+					_sid = req_id
+				else:
+					req_id, req = _cli.create_authn_request(
+						dest, vorg=vorg_name, sign=False, extensions=extensions)
+					msg_str = "%s" % req
+					_sid = req_id
+
+				if cert is not None:
+					self.outstanding_certs[_sid] = cert
+
+				ht_args = _cli.apply_binding(_binding, msg_str,
+											 destination=dest,
+											 relay_state=came_from)
+
+			except Exception, exc:
+				logger.exception(exc)
+				raise Exception(
+					"Failed to construct the AuthnRequest: %s" % exc)
+
+			try:
+				ret = _cli.config.getattr(
+					"endpoints", "sp")["discovery_response"][0][0]
+				if (environ["PATH_INFO"]) in ret and ret.split(
+						environ["PATH_INFO"])[1] == "":
+					query = parse_qs(environ["QUERY_STRING"])
+					sid = query["sid"][0]
+					came_from = self.outstanding_queries[sid]
+			except:
+				pass
+			# remember the request
+			self.outstanding_queries[_sid] = came_from
+
+			if not ht_args["data"] and ht_args["headers"][0][0] == "Location":
+				return HTTPSeeOther(headers=ht_args["headers"])
+			else:
+				return ht_args["data"]
+
+	def _construct_identity(self, session_info):
+		cni = code(session_info["name_id"])
+		identity = {
+			"login": cni,
+			"password": "",
+			'repoze.who.userid': cni,
+			"user": session_info["ava"],
+		}
+
+		return identity
+
+	def _eval_authn_response(self, environ, post, binding=BINDING_HTTP_POST):
+		try:
+			# Evaluate the response, returns a AuthnResponse instance
+			try:
+				authresp = self.saml_client.parse_authn_request_response(
+					post["SAMLResponse"][0], binding, self.outstanding_queries,
+					self.outstanding_certs)
+
+			except Exception, excp:
+				logger.exception("Exception: %s" % (excp,))
+				raise
+
+			session_info = authresp.session_info()
+		except TypeError, excp:
+			return None
+
+		if session_info["came_from"]:
+			try:
+				path, query = session_info["came_from"].split('?')
+				environ["PATH_INFO"] = path
+				environ["QUERY_STRING"] = query
+			except ValueError:
+				environ["PATH_INFO"] = session_info["came_from"]
+
+		return session_info
+
+	def do_ecp_response(self, body, environ):
+		response, _relay_state = ecp.handle_ecp_authn_response(self.saml_client,
+															   body)
+
+		environ["s2repoze.relay_state"] = _relay_state.text
+		session_info = response.session_info()
+
+		return session_info
+
+	#### IIdentifier ####
+	def identify(self, environ):
+		"""
+		Tries to do the identification
+		"""
+		query = parse_dict_querystring(environ)
+		if ("CONTENT_LENGTH" not in environ or not environ[
+			"CONTENT_LENGTH"]) and \
+						"SAMLResponse" not in query and "SAMLRequest" not in \
+				query:
+			return None
+
+		# if logger:
+		#	 logger.info("ENVIRON: %s" % environ)
+		#	 logger.info("self: %s" % (self.__dict__,))
+
+		uri = environ.get('REQUEST_URI', construct_url(environ))
+
+		query = parse_dict_querystring(environ)
+
+		if "SAMLResponse" in query or "SAMLRequest" in query:
+			post = query
+			binding = BINDING_HTTP_REDIRECT
+		else:
+			post = self._get_post(environ)
+			binding = BINDING_HTTP_POST
+
+		try:
+			path_info = environ['PATH_INFO']
+			logout = False
+			if path_info in self.logout_endpoints:
+				logout = True
+
+			if logout and "SAMLRequest" in post:
+				print("logout request received")
+				try:
+					response = self.saml_client.handle_logout_request(
+						post["SAMLRequest"][0],
+						self.saml_client.users.subjects()[0], binding)
+					environ['samlsp.pending'] = self._handle_logout(response)
+					return {}
+				except:
+					import traceback
+
+					traceback.print_exc()
+			elif "SAMLResponse" not in post:
+				# Not for me, put the post back where next in line can
+				# find it
+				environ["post.fieldstorage"] = post
+				# restore wsgi.input incase that is needed
+				# only of s2repoze.body is present
+				if 's2repoze.body' in environ:
+					environ['wsgi.input'] = StringIO(environ['s2repoze.body'])
+				return {}
+			else:
+				# check for SAML2 authN response
+				try:
+					if logout:
+						response = \
+							self.saml_client.parse_logout_request_response(
+							post["SAMLResponse"][0], binding)
+						if response:
+							action = self.saml_client.handle_logout_response(
+								response)
+
+							if type(action) == dict:
+								request = self._handle_logout(action)
+							else:
+								#logout complete
+								request = HTTPSeeOther(headers=[
+									('Location', "/")])
+							if request:
+								environ['samlsp.pending'] = request
+							return {}
+					else:
+						session_info = self._eval_authn_response(
+							environ, post,
+							binding=binding)
+				except Exception, err:
+					environ["s2repoze.saml_error"] = err
+					return {}
+		except TypeError, exc:
+			# might be a ECP (=SOAP) response
+			body = environ.get('s2repoze.body', None)
+			if body:
+				# might be a ECP response
+				try:
+					session_info = self.do_ecp_response(body, environ)
+				except Exception, err:
+					environ["post.fieldstorage"] = post
+					environ["s2repoze.saml_error"] = err
+					return {}
+			else:
+				exception_trace("sp.identity", exc, logger)
+				environ["post.fieldstorage"] = post
+				return {}
+
+		if session_info:
+			environ["s2repoze.sessioninfo"] = session_info
+			return self._construct_identity(session_info)
+		else:
+			return None
+
+	# IMetadataProvider
+	def add_metadata(self, environ, identity):
+		""" Add information to the knowledge I have about the user """
+		name_id = identity['repoze.who.userid']
+		if isinstance(name_id, basestring):
+			try:
+				# Make sure that userids authenticated by another plugin
+				# don't cause problems here.
+				name_id = decode(name_id)
+			except:
+				pass
+
+		_cli = self.saml_client
+
+		if "user" not in identity:
+			identity["user"] = {}
+		try:
+			(ava, _) = _cli.users.get_identity(name_id)
+			#now = time.gmtime()
+			identity["user"].update(ava)
+		except KeyError:
+			pass
+
+		if "pysaml2_vo_expanded" not in identity and _cli.vorg:
+			# is this a Virtual Organization situation
+			for vo in _cli.vorg.values():
+				try:
+					if vo.do_aggregation(name_id):
+						# Get the extended identity
+						identity["user"] = _cli.users.get_identity(name_id)[0]
+						# Only do this once, mark that the identity has been
+						# expanded
+						identity["pysaml2_vo_expanded"] = 1
+				except KeyError:
+					logger.exception("add_metadata -- Failed to do attribute aggregation, "
+									 "missing common attribute")
+
+		if not identity["user"]:
+			# remove cookie and demand re-authentication
+			pass
+
+	# used 2 times : one to get the ticket, the other to validate it
+	@staticmethod
+	def _service_url(environ, qstr=None):
+		if qstr is not None:
+			url = construct_url(environ, querystring=qstr)
+		else:
+			url = construct_url(environ)
+		return url
+
+	#### IAuthenticatorPlugin ####
+	#noinspection PyUnusedLocal
+	def authenticate(self, environ, identity=None):
+		if identity:
+			if identity.get('user') and environ.get(
+					's2repoze.sessioninfo') and identity.get(
+					'user') == environ.get('s2repoze.sessioninfo').get('ava'):
+				return identity.get('login')
+
+			tktuser = identity.get('repoze.who.plugins.auth_tkt.userid', None)
+
+			if tktuser and self.saml_client.is_logged_in(decode(tktuser)):
+				return tktuser
+			return None
+		else:
+			return None
+
+	@staticmethod
+	def _handle_logout(responses):
+		if 'data' in responses:
+			ht_args = responses
+		else:
+			ht_args = responses[responses.keys()[0]][1]
+		if not ht_args["data"] and ht_args["headers"][0][0] == "Location":
+			return HTTPSeeOther(headers=ht_args["headers"])
+		else:
+			return ht_args["data"]
+
+
+def make_plugin(remember_name=None,  # plugin for remember
+				cache="",  # cache
+				# Which virtual organization to support
+				virtual_organization="",
+				saml_conf="",
+				wayf="",
+				sid_store="",
+				identity_cache="",
+				discovery="",
+				idp_query_param=""
+):
+	logger.info("make_plugin: START")
+	if saml_conf is "":
+		raise ValueError(
+			'must include saml_conf in configuration')
+
+	if remember_name is None:
+		raise ValueError('must include remember_name in configuration')
+
+	conf = config_factory("sp", saml_conf)
+
+	scl = Saml2Client(config=conf, identity_cache=identity_cache,
+					  virtual_organization=virtual_organization)
+
+	plugin = SAML2Plugin(remember_name, conf, scl, wayf, cache, sid_store,
+						 discovery, idp_query_param)
+	return plugin

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -120,7 +120,7 @@ class SAML2GenericPlugin(object):
 
 	def _get_outstanding_queries(self):
 		if self.sid_store_type == 'memcache':
-			return self.outstanding_query_store.get(QUERY_STORE_KEY, {})
+			return self.outstanding_query_store.get(QUERY_STORE_KEY) or {}
 
 		return self.outstanding_query_store
 
@@ -128,6 +128,7 @@ class SAML2GenericPlugin(object):
 		return self._get_outstanding_queries.get(key)
 
 	def _set_outstanding_query(self, key, value):
+		logger.debug('sid_store_type: {0}'.format(sid_store_type))
 		if self.sid_store_type == 'memcache':
 			queries = self._get_outstanding_queries()
 			queries[key] = value
@@ -137,7 +138,7 @@ class SAML2GenericPlugin(object):
 
 	def _get_outstanding_certs(self):
 		if self.sid_store_type == 'memcache':
-			return self.outstanding_cert_store.get(CERT_STORE_KEY)
+			return self.outstanding_cert_store.get(CERT_STORE_KEY) or {}
 
 		return self.outstanding_cert_store
 

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -114,7 +114,7 @@ class SAML2GenericPlugin(object):
 			else:
 				self.outstanding_cert_store = shelve.open(sid_store_cert, writeback=True)
 		else:
-			self.outstanding_certs = {}
+			self.outstanding_cert_store = {}
 
 		self.iam = platform.node()
 

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -546,7 +546,7 @@ class SAML2GenericPlugin(object):
 					'userdata') == environ.get('s2repoze.sessioninfo').get('ava'):
 				return identity.get('login')
 
-			tktuser = identity.get('repoze.who.plugins.auth_tkt.userid', None)
+			tktuser = identity.get('altid', None)
 
 			if tktuser and self.saml_client.is_logged_in(decode(tktuser)):
 				return tktuser

--- a/src/s2repoze/plugins/generic_sp.py
+++ b/src/s2repoze/plugins/generic_sp.py
@@ -83,8 +83,8 @@ class SAML2GenericPlugin(object):
 	implements(IChallenger, IIdentifier, IAuthenticator, IMetadataProvider)
 
 	def __init__(self, rememberer_name, config, saml_client, wayf, cache,
-				 sid_store=None, sid_store_type='local', discovery="", idp_query_param="",
-				 sid_store_cert=None, sid_store_cert_type='local'):
+				 sid_store=None, sid_store_type=None, discovery="", idp_query_param="",
+				 sid_store_cert=None, sid_store_cert_type=None):
 		self.rememberer_name = rememberer_name
 		self.wayf = wayf
 		self.saml_client = saml_client
@@ -92,8 +92,8 @@ class SAML2GenericPlugin(object):
 		self.cache = cache
 		self.discosrv = discovery
 		self.idp_query_param = idp_query_param
-		self.sid_store_type = sid_store_type.lower()
-		self.sid_store_cert_type = sid_store_cert_type.lower()
+		self.sid_store_type = (sid_store_type or 'local').lower()
+		self.sid_store_cert_type = (sid_store_cert_type or 'local').lower()
 		self.logout_endpoints = [urlparse(ep)[2] for ep in config.endpoint(
 			"single_logout_service")]
 		try:

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -121,9 +121,9 @@ class SAML2Plugin(object):
 
     #### IIdentifier ####
     def remember(self, environ, identity):
-        logger.debug("s2repoze, SAML2Plugin: remember")
+        logger.debug("remember : Start")
         rememberer = self._get_rememberer(environ)
-        logger.debug("s2repoze, SAML2Plugin, remember: REMEMBERER %s" % rememberer)
+        logger.debug("PCROWNOV - REMEMBERER %s" % rememberer)
         return rememberer.remember(environ, identity)
 
     #### IIdentifier ####

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -642,7 +642,7 @@ class SAML2Plugin(object):
             if tktuser:
                 logger.debug('s2repoze, SAML2Plugin, authenticate: LOGGED IN USER: %s ' % self.saml_client.is_logged_in(decode(tktuser)))
             if tktuser and self.saml_client.is_logged_in(decode(tktuser)):
-                logger.debug('s2repoze, SAML2Plugin, authenticate: IS LOGGED IN: TRUE")
+                logger.debug('s2repoze, SAML2Plugin, authenticate: IS LOGGED IN: TRUE')
                 return tktuser
             return None
         else:

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -675,7 +675,6 @@ def make_plugin(remember_name=None,  # plugin for remember
                 discovery="",
                 idp_query_param=""
 ):
-    print "TESTING"
     logger.info("s2repoze: make_plugin")
     if saml_conf is "":
         raise ValueError(

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -134,6 +134,8 @@ class SAML2Plugin(object):
 	#### IIdentifier ####
 	def remember(self, environ, identity, **kw):
 		logger.debug("remember : START")
+		logger.debug("remember -- IDENTITY: {0}".format(identity))
+		logger.debug("remember -- ENVIRON: {0}".format(environ))
 		rememberer = self._get_rememberer(environ)
 		logger.debug("remember -- REMEMBERER: %s" % rememberer)
 		if not rememberer:

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -119,7 +119,11 @@ class SAML2Plugin(object):
 			logger.debug("_get_rememberer: No Plugin stored in environment")
 			return None
 		api_identifiers = api.identifiers
-		rememberer = api_identifiers.get(self.rememberer_name, None)
+		rememberer = None
+		for rememberer_set in api_identifiers:
+			if rememberer_set and rememberer_set[0] == self.rememberer_name:
+				rememberer = rememberer_set[1]
+
 		if not rememberer:
 			logger.debug("_get_rememberer -- No Remberer of name %s stored in API" % self.rememberer_name)
 

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -113,9 +113,10 @@ class SAML2Plugin(object):
     def _get_rememberer(self, environ):
         logger.debug("s2repoze, SAML2Plugin: _get_rememberer")
         repoze_plugins = environ.get('repoze.who.plugins', None)
-        rememberer = None
-        if repoze_plugins:
-            rememberer = repoze_plugins.get(self.rememberer_name, None)
+        if not repoze_plugins
+            logger.debug("s2repoze, SAML2Plugin: _get_rememberer: No Plugin stored in environment")
+            return None
+        rememberer = repoze_plugins.get(self.rememberer_name, None)
         logger.debug('s2repoze, SAML2Plugin, _get_rememberer: REMEMBERER %s' % rememberer)
         return rememberer
 
@@ -124,6 +125,8 @@ class SAML2Plugin(object):
         logger.debug("remember : Start")
         rememberer = self._get_rememberer(environ)
         logger.debug("PCROWNOV - REMEMBERER %s" % rememberer)
+        if not rememberer:
+            return []
         return rememberer.remember(environ, identity)
 
     #### IIdentifier ####
@@ -131,6 +134,8 @@ class SAML2Plugin(object):
         logger.debug("s2repoze, SAML2Plugin: forget")
         rememberer = self._get_rememberer(environ)
         logger.debug("s2repoze, SAML2Plugin, forget: REMEMBERER %s" % rememberer)
+        if not rememberer:
+            return []
         return rememberer.forget(environ, identity)
 
     def _get_post(self, environ):

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -127,7 +127,7 @@ class SAML2Plugin(object):
 		return rememberer
 
 	#### IIdentifier ####
-	def remember(self, request, principal, **kw):
+	def remember(self, environ, identity, **kw):
 		logger.debug("remember : START")
 		rememberer = self._get_rememberer(environ)
 		logger.debug("remember -- REMEMBERER: %s" % rememberer)
@@ -137,7 +137,7 @@ class SAML2Plugin(object):
 
 
 	#### IIdentifier ####
-	def forget(self, request, identity):
+	def forget(self, environ, identity):
 		"""Get headers to forget the identify of the given request.
 
 		This method calls the repoze.who logout() method, which in turn calls

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -120,10 +120,17 @@ class SAML2Plugin(object):
 			return None
 		#rememberer = repoze_plugins.get(self.rememberer_name, None)
 		logger.debug('_get_api: API %s' % api)
+		logger.debug('_get_api: API CLASSES %s' % (dir(api)))
 		return api
 
 	#### IIdentifier ####
 	def remember(self, request, principal, **kw):
+		#logger.debug("remember : START")
+		#rememberer = self._get_rememberer(environ)
+		#logger.debug("remember -- REMEMBERER: %s" % rememberer)
+		#if not rememberer:
+		#	return []
+		#return rememberer.remember(environ, identity)
 		"""Get headers to remember the given principal.
 
 		This method calls the remember() method on all configured repoze.who

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -143,7 +143,7 @@ class SAML2Plugin(object):
 		return headers
 
 	#### IIdentifier ####
-	def forget(self, environ, identity):
+	def forget(self, request):
 		"""Get headers to forget the identify of the given request.
 
 		This method calls the repoze.who logout() method, which in turn calls

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -112,7 +112,10 @@ class SAML2Plugin(object):
 
     def _get_rememberer(self, environ):
         logger.info("s2repoze, SAML2Plugin: _get_rememberer")
-        rememberer = environ['repoze.who.plugins'][self.rememberer_name]
+        repoze_plugins = environ.get('repoze.who.plugins', None)
+        rememberer = None
+        if repoze_plugins:
+            rememberer = repoze_plugins.get(self.rememberer_name, None)
         return rememberer
 
     #### IIdentifier ####
@@ -662,6 +665,7 @@ def make_plugin(remember_name=None,  # plugin for remember
                 discovery="",
                 idp_query_param=""
 ):
+    console.log("TESTING")
     logger.info("s2repoze: make_plugin")
     if saml_conf is "":
         raise ValueError(

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -121,6 +121,7 @@ class SAML2Plugin(object):
 		#rememberer = repoze_plugins.get(self.rememberer_name, None)
 		logger.debug('_get_api: API %s' % api)
 		logger.debug('_get_api: API CLASSES %s' % (dir(api)))
+		logger.debug('_get_api: API IDENTIFIERS %s' % (api.identifiers))
 		return api
 
 	#### IIdentifier ####

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -143,7 +143,7 @@ class SAML2Plugin(object):
 		return headers
 
 	#### IIdentifier ####
-	def forget(self, request):
+	def forget(self, request, identity):
 		"""Get headers to forget the identify of the given request.
 
 		This method calls the repoze.who logout() method, which in turn calls

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -85,6 +85,7 @@ class SAML2Plugin(object):
     def __init__(self, rememberer_name, config, saml_client, wayf, cache,
                  sid_store=None, discovery="", idp_query_param="",
                  sid_store_cert=None, ):
+        logger.info("s2repoze, SAML2Plugin: INIT")
         self.rememberer_name = rememberer_name
         self.wayf = wayf
         self.saml_client = saml_client
@@ -110,16 +111,19 @@ class SAML2Plugin(object):
         self.iam = platform.node()
 
     def _get_rememberer(self, environ):
+        logger.info("s2repoze, SAML2Plugin: _get_rememberer")
         rememberer = environ['repoze.who.plugins'][self.rememberer_name]
         return rememberer
 
     #### IIdentifier ####
     def remember(self, environ, identity):
+        logger.info("s2repoze, SAML2Plugin: remember")
         rememberer = self._get_rememberer(environ)
         return rememberer.remember(environ, identity)
 
     #### IIdentifier ####
     def forget(self, environ, identity):
+        logger.info("s2repoze, SAML2Plugin: forget")
         rememberer = self._get_rememberer(environ)
         return rememberer.forget(environ, identity)
 
@@ -130,6 +134,7 @@ class SAML2Plugin(object):
         :param environ: A dictionary with environment variables
         """
 
+        logger.info("s2repoze, SAML2Plugin: _get_post")
         body = ''
         try:
             length = int(environ.get('CONTENT_LENGTH', '0'))
@@ -150,6 +155,7 @@ class SAML2Plugin(object):
         return post
 
     def _wayf_redirect(self, came_from):
+        logger.info("s2repoze, SAML2Plugin: _wayf_redirect")
         sid_ = sid()
         self.outstanding_queries[sid_] = came_from
         logger.info("Redirect to WAYF function: %s" % self.wayf)
@@ -162,6 +168,7 @@ class SAML2Plugin(object):
         If more than one idp and if none is selected, I have to do wayf or
         disco
         """
+        logger.info("s2repoze, SAML2Plugin: _pick_idp")
 
         # check headers to see if it's an ECP request
         #        headers = {
@@ -264,6 +271,7 @@ class SAML2Plugin(object):
     #noinspection PyUnusedLocal
     def challenge(self, environ, _status, _app_headers, _forget_headers):
 
+        logger.info("s2repoze, SAML2Plugin: challenge")
         _cli = self.saml_client
 
         if 'REMOTE_USER' in environ:
@@ -381,6 +389,7 @@ class SAML2Plugin(object):
                 return ht_args["data"]
 
     def _construct_identity(self, session_info):
+        logger.info("s2repoze, SAML2Plugin: _construct_identity")
         cni = code(session_info["name_id"])
         identity = {
             "login": cni,
@@ -393,6 +402,7 @@ class SAML2Plugin(object):
         return identity
 
     def _eval_authn_response(self, environ, post, binding=BINDING_HTTP_POST):
+        logger.info("s2repoze, SAML2Plugin: _eval_authn_response")
         logger.info("Got AuthN response, checking..")
         logger.info("Outstanding: %s" % (self.outstanding_queries,))
 
@@ -425,6 +435,7 @@ class SAML2Plugin(object):
         return session_info
 
     def do_ecp_response(self, body, environ):
+        logger.info("s2repoze, SAML2Plugin: do_ecp_response")
         response, _relay_state = ecp.handle_ecp_authn_response(self.saml_client,
                                                                body)
 
@@ -439,6 +450,7 @@ class SAML2Plugin(object):
         """
         Tries to do the identification
         """
+        logger.info("s2repoze, SAML2Plugin: identity")
         #logger = environ.get('repoze.who.logger', '')
 
         query = parse_dict_querystring(environ)
@@ -554,6 +566,7 @@ class SAML2Plugin(object):
     # IMetadataProvider
     def add_metadata(self, environ, identity):
         """ Add information to the knowledge I have about the user """
+        logger.info("s2repoze, SAML2Plugin: add_metadata")
         name_id = identity['repoze.who.userid']
         if isinstance(name_id, basestring):
             try:
@@ -611,6 +624,7 @@ class SAML2Plugin(object):
     #### IAuthenticatorPlugin ####
     #noinspection PyUnusedLocal
     def authenticate(self, environ, identity=None):
+        logger.info("s2repoze, SAML2Plugin: authenticate")
         if identity:
             if identity.get('user') and environ.get(
                     's2repoze.sessioninfo') and identity.get(
@@ -625,6 +639,7 @@ class SAML2Plugin(object):
 
     @staticmethod
     def _handle_logout(responses):
+        logger.info("s2repoze, SAML2Plugin: _handle_logout")
         if 'data' in responses:
             ht_args = responses
         else:
@@ -647,6 +662,7 @@ def make_plugin(remember_name=None,  # plugin for remember
                 discovery="",
                 idp_query_param=""
 ):
+    logger.info("s2repoze: make_plugin")
     if saml_conf is "":
         raise ValueError(
             'must include saml_conf in configuration')

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -85,7 +85,7 @@ class SAML2Plugin(object):
     def __init__(self, rememberer_name, config, saml_client, wayf, cache,
                  sid_store=None, discovery="", idp_query_param="",
                  sid_store_cert=None, ):
-        logger.info("s2repoze, SAML2Plugin: INIT")
+        logger.info("__init__: START")
         self.rememberer_name = rememberer_name
         self.wayf = wayf
         self.saml_client = saml_client
@@ -111,29 +111,30 @@ class SAML2Plugin(object):
         self.iam = platform.node()
 
     def _get_rememberer(self, environ):
-        logger.debug("s2repoze, SAML2Plugin: _get_rememberer")
+        logger.debug("_get_rememberer: START")
+        logger.debug("_get_rememberer -- ENVIRON : %s " % environ)
         repoze_plugins = environ.get('repoze.who.plugins', None)
         if not repoze_plugins:
-            logger.debug("s2repoze, SAML2Plugin: _get_rememberer: No Plugin stored in environment")
+            logger.debug("_get_rememberer: No Plugin stored in environment")
             return None
         rememberer = repoze_plugins.get(self.rememberer_name, None)
-        logger.debug('s2repoze, SAML2Plugin, _get_rememberer: REMEMBERER %s' % rememberer)
+        logger.debug('_get_rememberer: REMEMBERER %s' % rememberer)
         return rememberer
 
     #### IIdentifier ####
     def remember(self, environ, identity):
-        logger.debug("remember : Start")
+        logger.debug("remember : START")
         rememberer = self._get_rememberer(environ)
-        logger.debug("PCROWNOV - REMEMBERER %s" % rememberer)
+        logger.debug("remember -- REMEMBERER: %s" % rememberer)
         if not rememberer:
             return []
         return rememberer.remember(environ, identity)
 
     #### IIdentifier ####
     def forget(self, environ, identity):
-        logger.debug("s2repoze, SAML2Plugin: forget")
+        logger.debug("forget: START")
         rememberer = self._get_rememberer(environ)
-        logger.debug("s2repoze, SAML2Plugin, forget: REMEMBERER %s" % rememberer)
+        logger.debug("forget: REMEMBERER %s" % rememberer)
         if not rememberer:
             return []
         return rememberer.forget(environ, identity)
@@ -145,7 +146,7 @@ class SAML2Plugin(object):
         :param environ: A dictionary with environment variables
         """
 
-        logger.info("s2repoze, SAML2Plugin: _get_post")
+        logger.info("_get_post: START")
         body = ''
         try:
             length = int(environ.get('CONTENT_LENGTH', '0'))
@@ -161,15 +162,15 @@ class SAML2Plugin(object):
 
         post = parse_qs(body)  # parse the POST fields into a dict
 
-        logger.debug('identify post: %s' % (post,))
+        logger.debug('_get_post -- identify post: %s' % (post,))
 
         return post
 
     def _wayf_redirect(self, came_from):
-        logger.info("s2repoze, SAML2Plugin: _wayf_redirect")
+        logger.info("_wayf_redirect: START")
         sid_ = sid()
         self.outstanding_queries[sid_] = came_from
-        logger.info("Redirect to WAYF function: %s" % self.wayf)
+        logger.info("_wayf_redirect -- Redirect to WAYF function: %s" % self.wayf)
         return -1, HTTPSeeOther(headers=[('Location',
                                           "%s?%s" % (self.wayf, sid_))])
 
@@ -179,7 +180,7 @@ class SAML2Plugin(object):
         If more than one idp and if none is selected, I have to do wayf or
         disco
         """
-        logger.info("s2repoze, SAML2Plugin: _pick_idp")
+        logger.info("_pick_idp: START")
 
         # check headers to see if it's an ECP request
         #        headers = {

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -111,7 +111,7 @@ class SAML2Plugin(object):
         self.iam = platform.node()
 
     def _get_rememberer(self, environ):
-        logger.info("s2repoze, SAML2Plugin: _get_rememberer")
+        logger.debug("s2repoze, SAML2Plugin: _get_rememberer")
         repoze_plugins = environ.get('repoze.who.plugins', None)
         rememberer = None
         if repoze_plugins:
@@ -121,16 +121,16 @@ class SAML2Plugin(object):
 
     #### IIdentifier ####
     def remember(self, environ, identity):
-        logger.info("s2repoze, SAML2Plugin: remember")
+        logger.debug("s2repoze, SAML2Plugin: remember")
         rememberer = self._get_rememberer(environ)
-        logger.info("s2repoze, SAML2Plugin, remember: REMEMBERER %s" % rememberer)
+        logger.debug("s2repoze, SAML2Plugin, remember: REMEMBERER %s" % rememberer)
         return rememberer.remember(environ, identity)
 
     #### IIdentifier ####
     def forget(self, environ, identity):
-        logger.info("s2repoze, SAML2Plugin: forget")
+        logger.debug("s2repoze, SAML2Plugin: forget")
         rememberer = self._get_rememberer(environ)
-        logger.info("s2repoze, SAML2Plugin, forget: REMEMBERER %s" % rememberer)
+        logger.debug("s2repoze, SAML2Plugin, forget: REMEMBERER %s" % rememberer)
         return rememberer.forget(environ, identity)
 
     def _get_post(self, environ):

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -49,657 +49,670 @@ PAOS_HEADER_INFO = 'ver="%s";"%s"' % (paos.NAMESPACE, ECP_SERVICE)
 
 
 def construct_came_from(environ):
-    """ The URL that the user used when the process where interupted
-    for single-sign-on processing. """
+	""" The URL that the user used when the process where interupted
+	for single-sign-on processing. """
 
-    came_from = environ.get("PATH_INFO")
-    qstr = environ.get("QUERY_STRING", "")
-    if qstr:
-        came_from += '?' + qstr
-    return came_from
+	came_from = environ.get("PATH_INFO")
+	qstr = environ.get("QUERY_STRING", "")
+	if qstr:
+		came_from += '?' + qstr
+	return came_from
 
 
 def exception_trace(tag, exc, log):
-    message = traceback.format_exception(*sys.exc_info())
-    log.error("[%s] ExcList: %s" % (tag, "".join(message),))
-    log.error("[%s] Exception: %s" % (tag, exc))
+	message = traceback.format_exception(*sys.exc_info())
+	log.error("[%s] ExcList: %s" % (tag, "".join(message),))
+	log.error("[%s] Exception: %s" % (tag, exc))
 
 
 class ECP_response(object):
-    code = 200
-    title = 'OK'
+	code = 200
+	title = 'OK'
 
-    def __init__(self, content):
-        self.content = content
+	def __init__(self, content):
+		self.content = content
 
-    #noinspection PyUnusedLocal
-    def __call__(self, environ, start_response):
-        start_response('%s %s' % (self.code, self.title),
-                       [('Content-Type', "text/xml")])
-        return [self.content]
+	#noinspection PyUnusedLocal
+	def __call__(self, environ, start_response):
+		start_response('%s %s' % (self.code, self.title),
+					   [('Content-Type', "text/xml")])
+		return [self.content]
 
 
 class SAML2Plugin(object):
-    implements(IChallenger, IIdentifier, IAuthenticator, IMetadataProvider)
-
-    def __init__(self, rememberer_name, config, saml_client, wayf, cache,
-                 sid_store=None, discovery="", idp_query_param="",
-                 sid_store_cert=None, ):
-        logger.info("__init__: START")
-        self.rememberer_name = rememberer_name
-        self.wayf = wayf
-        self.saml_client = saml_client
-        self.conf = config
-        self.cache = cache
-        self.discosrv = discovery
-        self.idp_query_param = idp_query_param
-        self.logout_endpoints = [urlparse(ep)[2] for ep in config.endpoint(
-            "single_logout_service")]
-        try:
-            self.metadata = self.conf.metadata
-        except KeyError:
-            self.metadata = None
-        if sid_store:
-            self.outstanding_queries = shelve.open(sid_store, writeback=True)
-        else:
-            self.outstanding_queries = {}
-        if sid_store_cert:
-            self.outstanding_certs = shelve.open(sid_store_cert, writeback=True)
-        else:
-            self.outstanding_certs = {}
-        logger.info("__init__ -- Outstanding Queries: %s" % self.outstanding_queries)
-
-        self.iam = platform.node()
-
-    def _get_rememberer(self, environ):
-        logger.debug("_get_rememberer: START")
-        logger.debug("_get_rememberer -- ENVIRON : %s " % environ)
-        repoze_plugins = environ.get('repoze.who.api', None)
-        if not repoze_plugins:
-            logger.debug("_get_rememberer: No Plugin stored in environment")
-            return None
-        rememberer = repoze_plugins.get(self.rememberer_name, None)
-        logger.debug('_get_rememberer: REMEMBERER %s' % rememberer)
-        return rememberer
-
-    #### IIdentifier ####
-    def remember(self, environ, identity):
-        logger.debug("remember : START")
-        rememberer = self._get_rememberer(environ)
-        logger.debug("remember -- REMEMBERER: %s" % rememberer)
-        if not rememberer:
-            return []
-        return rememberer.remember(environ, identity)
-
-    #### IIdentifier ####
-    def forget(self, environ, identity):
-        logger.debug("forget: START")
-        rememberer = self._get_rememberer(environ)
-        logger.debug("forget: REMEMBERER %s" % rememberer)
-        if not rememberer:
-            return []
-        return rememberer.forget(environ, identity)
-
-    def _get_post(self, environ):
-        """
-        Get the posted information
-
-        :param environ: A dictionary with environment variables
-        """
-
-        logger.info("_get_post: START")
-        body = ''
-        try:
-            length = int(environ.get('CONTENT_LENGTH', '0'))
-        except ValueError:
-            length = 0
-        if length != 0:
-            body = environ['wsgi.input'].read(length)  # get the POST variables
-            environ[
-                's2repoze.body'] = body  # store the request body for later
-                # use by pysaml2
-            environ['wsgi.input'] = StringIO(body)  # restore the request body
-                # as a stream so that everything seems untouched
-
-        post = parse_qs(body)  # parse the POST fields into a dict
-
-        logger.debug('_get_post -- identify post: %s' % (post,))
-
-        return post
-
-    def _wayf_redirect(self, came_from):
-        logger.info("_wayf_redirect: START")
-        sid_ = sid()
-        self.outstanding_queries[sid_] = came_from
-        logger.info("_wayf_redirect -- Outstanding Queries: %s" % self.outstanding_queries)
-        logger.info("_wayf_redirect -- Redirect to WAYF function: %s" % self.wayf)
-        return -1, HTTPSeeOther(headers=[('Location',
-                                          "%s?%s" % (self.wayf, sid_))])
-
-    #noinspection PyUnusedLocal
-    def _pick_idp(self, environ, came_from):
-        """
-        If more than one idp and if none is selected, I have to do wayf or
-        disco
-        """
-        logger.info("_pick_idp: START")
-
-        # check headers to see if it's an ECP request
-        #        headers = {
-        #                    'Accept' : 'text/html; application/vnd.paos+xml',
-        #                    'PAOS'   : 'ver="%s";"%s"' % (paos.NAMESPACE,
-        # SERVICE)
-        #                    }
-
-        _cli = self.saml_client
-
-        logger.info("_pick_idp -- [_pick_idp] Environment: %s" % environ)
-        if "HTTP_PAOS" in environ:
-            if environ["HTTP_PAOS"] == PAOS_HEADER_INFO:
-                if 'application/vnd.paos+xml' in environ["HTTP_ACCEPT"]:
-                    # Where should I redirect the user to
-                    # entityid -> the IdP to use
-                    # relay_state -> when back from authentication
-
-                    logger.info("_pick_idp -- - ECP client detected -")
-
-                    _relay_state = construct_came_from(environ)
-                    _entityid = _cli.config.ecp_endpoint(environ["REMOTE_ADDR"])
-
-                    if not _entityid:
-                        return -1, HTTPInternalServerError(
-                            detail="No IdP to talk to")
-                    logger.info("_pick_idp -- IdP to talk to: %s" % _entityid)
-                    return ecp.ecp_auth_request(_cli, _entityid,
-                                                _relay_state)
-                else:
-                    return -1, HTTPInternalServerError(
-                        detail='Faulty Accept header')
-            else:
-                return -1, HTTPInternalServerError(
-                    detail='unknown ECP version')
-
-        idps = self.metadata.with_descriptor("idpsso")
-
-        logger.info("_pick_idp -- IdP Data: %s" % idps)
-
-        idp_entity_id = query = None
-
-        for key in ['s2repoze.body', "QUERY_STRING"]:
-            query = environ.get(key)
-            if query:
-                try:
-                    _idp_entity_id = dict(parse_qs(query))[
-                        self.idp_query_param][0]
-                    if _idp_entity_id in idps:
-                        idp_entity_id = _idp_entity_id
-                    break
-                except KeyError:
-                    logger.debug("_pick_idp -- No IdP entity ID in query: %s" % query)
-                    pass
-
-        if idp_entity_id is None:
-            if len(idps) == 1:
-                # idps is a dictionary
-                idp_entity_id = idps.keys()[0]
-            elif not len(idps):
-                return -1, HTTPInternalServerError(detail='Misconfiguration')
-            else:
-                idp_entity_id = ""
-                logger.info("_pick_idp -- ENVIRON: %s" % environ)
-
-                if self.wayf:
-                    if query:
-                        try:
-                            wayf_selected = dict(parse_qs(query))[
-                                "wayf_selected"][0]
-                        except KeyError:
-                            return self._wayf_redirect(came_from)
-                        idp_entity_id = wayf_selected
-                    else:
-                        return self._wayf_redirect(came_from)
-                elif self.discosrv:
-                    if query:
-                        idp_entity_id = _cli.parse_discovery_service_response(
-                            query=environ.get("QUERY_STRING"))
-                    else:
-                        sid_ = sid()
-                        self.outstanding_queries[sid_] = came_from
-                        logger.info("_pick_idp -- Outstanding Queries: %s" % self.outstanding_queries)
-                        logger.debug("_pick_idp -- Redirect to Discovery Service function")
-                        eid = _cli.config.entityid
-                        ret = _cli.config.getattr(
-                            "endpoints", "sp")["discovery_response"][0][0]
-                        ret += "?sid=%s" % sid_
-                        loc = _cli.create_discovery_service_request(
-                            self.discosrv, eid, **{"return": ret})
-                        return -1, SeeOther(loc)
-
-                else:
-                    return -1, HTTPNotImplemented(
-                        detail='No WAYF or DJ present!')
-
-        logger.info("_pick_idp -- Chosen IdP: '%s'" % idp_entity_id)
-        return 0, idp_entity_id
-
-    #### IChallenger ####
-    #noinspection PyUnusedLocal
-    def challenge(self, environ, _status, _app_headers, _forget_headers):
-
-        logger.info("challenge: START")
-        _cli = self.saml_client
-
-        if 'REMOTE_USER' in environ:
-            name_id = decode(environ["REMOTE_USER"])
-
-            _cli = self.saml_client
-            path_info = environ['PATH_INFO']
-
-            if 'samlsp.logout' in environ:
-                responses = _cli.global_logout(name_id)
-                return self._handle_logout(responses)
-
-        if 'samlsp.pending' in environ:
-            response = environ['samlsp.pending']
-            if isinstance(response, HTTPRedirection):
-                response.headers += _forget_headers
-            return response
-
-        #logger = environ.get('repoze.who.logger','')
-
-        # Which page was accessed to get here
-        came_from = construct_came_from(environ)
-        environ["myapp.came_from"] = came_from
-        logger.debug("challenge -- [sp.challenge] RelayState >> '%s'" % came_from)
-
-        # Am I part of a virtual organization or more than one ?
-        try:
-            vorg_name = environ["myapp.vo"]
-        except KeyError:
-            try:
-                vorg_name = _cli.vorg._name
-            except AttributeError:
-                vorg_name = ""
-
-        logger.info("challenge -- [sp.challenge] VO: %s" % vorg_name)
-
-        # If more than one idp and if none is selected, I have to do wayf
-        (done, response) = self._pick_idp(environ, came_from)
-        # Three cases: -1 something went wrong or Discovery service used
-        #               0 I've got an IdP to send a request to
-        #               >0 ECP in progress
-        logger.debug("challenge -- _idp_pick returned: Status:%s, URL:%s" % (done, response))
-        if done == -1:
-            return response
-        elif done > 0:
-            self.outstanding_queries[done] = came_from
-            logger.info("challenge -- Outstanding Queries: %s" % self.outstanding_queries)
-            return ECP_response(response)
-        else:
-            entity_id = response
-            logger.info("challenge -- [sp.challenge] entity_id: %s" % entity_id)
-            # Do the AuthnRequest
-            _binding = BINDING_HTTP_REDIRECT
-            try:
-                srvs = _cli.metadata.single_sign_on_service(entity_id, _binding)
-                logger.debug("challenge -- srvs: %s" % srvs)
-                dest = srvs[0]["location"]
-                logger.debug("challenge -- destination: %s" % dest)
-
-                extensions = None
-                cert = None
-
-                if _cli.config.generate_cert_func is not None:
-                    cert_str, req_key_str = _cli.config.generate_cert_func()
-                    cert = {
-                        "cert": cert_str,
-                        "key": req_key_str
-                    }
-                    spcertenc = SPCertEnc(x509_data=ds.X509Data(
-                        x509_certificate=ds.X509Certificate(text=cert_str)))
-                    extensions = Extensions(extension_elements=[
-                        element_to_extension_element(spcertenc)])
-
-                if _cli.authn_requests_signed:
-                    _sid = saml2.s_utils.sid(_cli.seed)
-                    req_id, msg_str = _cli.create_authn_request(
-                        dest, vorg=vorg_name, sign=_cli.authn_requests_signed,
-                        message_id=_sid, extensions=extensions)
-                    _sid = req_id
-                else:
-                    req_id, req = _cli.create_authn_request(
-                        dest, vorg=vorg_name, sign=False, extensions=extensions)
-                    msg_str = "%s" % req
-                    _sid = req_id
-
-                if cert is not None:
-                    self.outstanding_certs[_sid] = cert
-
-                ht_args = _cli.apply_binding(_binding, msg_str,
-                                             destination=dest,
-                                             relay_state=came_from)
-
-                logger.debug("challenge -- ht_args: %s" % ht_args)
-            except Exception, exc:
-                logger.exception(exc)
-                raise Exception(
-                    "Failed to construct the AuthnRequest: %s" % exc)
-
-            try:
-                ret = _cli.config.getattr(
-                    "endpoints", "sp")["discovery_response"][0][0]
-                if (environ["PATH_INFO"]) in ret and ret.split(
-                        environ["PATH_INFO"])[1] == "":
-                    query = parse_qs(environ["QUERY_STRING"])
-                    sid = query["sid"][0]
-                    came_from = self.outstanding_queries[sid]
-                    logger.info("_challenge -- Outstanding Queries: %s" % self.outstanding_queries)
-            except:
-                pass
-            logger.debug('challenge -- REMEMBER REQUEST : %s ' % came_from)
-            # remember the request
-            self.outstanding_queries[_sid] = came_from
-            logger.info("challenge -- Outstanding Queries: %s" % self.outstanding_queries)
-
-            if not ht_args["data"] and ht_args["headers"][0][0] == "Location":
-                logger.debug('challenge -- redirect to: %s' % ht_args["headers"][0][1])
-                return HTTPSeeOther(headers=ht_args["headers"])
-            else:
-                return ht_args["data"]
-
-    def _construct_identity(self, session_info):
-        logger.info("_construct_identity: START")
-        cni = code(session_info["name_id"])
-        identity = {
-            "login": cni,
-            "password": "",
-            'repoze.who.userid': cni,
-            "user": session_info["ava"],
-        }
-        logger.debug("_construct_identity -- Identity: %s" % identity)
-
-        return identity
-
-    def _eval_authn_response(self, environ, post, binding=BINDING_HTTP_POST):
-        logger.info("_eval_authn_response: START")
-        logger.info("_eval_authn_response -- Got AuthN response, checking..")
-        logger.info("_eval_authn_response -- Outstanding: %s" % (self.outstanding_queries))
-
-        try:
-            # Evaluate the response, returns a AuthnResponse instance
-            try:
-                authresp = self.saml_client.parse_authn_request_response(
-                    post["SAMLResponse"][0], binding, self.outstanding_queries,
-                    self.outstanding_certs)
-
-            except Exception, excp:
-                logger.exception("Exception: %s" % (excp,))
-                raise
-
-            session_info = authresp.session_info()
-        except TypeError, excp:
-            logger.exception("_eval_authn_response -- Exception: %s" % (excp,))
-            return None
-
-        if session_info["came_from"]:
-            logger.debug("_eval_authn_response --came_from << %s" % session_info["came_from"])
-            try:
-                path, query = session_info["came_from"].split('?')
-                environ["PATH_INFO"] = path
-                environ["QUERY_STRING"] = query
-            except ValueError:
-                environ["PATH_INFO"] = session_info["came_from"]
-
-        logger.info("_eval_authn_response --Session_info: %s" % session_info)
-        return session_info
-
-    def do_ecp_response(self, body, environ):
-        logger.info("do_ecp_response: START")
-        response, _relay_state = ecp.handle_ecp_authn_response(self.saml_client,
-                                                               body)
-
-        environ["s2repoze.relay_state"] = _relay_state.text
-        session_info = response.session_info()
-        logger.info("do_ecp_response -- Session_info: %s" % session_info)
-
-        return session_info
-
-    #### IIdentifier ####
-    def identify(self, environ):
-        """
-        Tries to do the identification
-        """
-        logger.info("identify: START")
-        #logger = environ.get('repoze.who.logger', '')
-
-        query = parse_dict_querystring(environ)
-        if ("CONTENT_LENGTH" not in environ or not environ[
-            "CONTENT_LENGTH"]) and \
-                        "SAMLResponse" not in query and "SAMLRequest" not in \
-                query:
-            logger.debug('identify -- [identify] get or empty post')
-            return None
-
-        # if logger:
-        #     logger.info("ENVIRON: %s" % environ)
-        #     logger.info("self: %s" % (self.__dict__,))
-
-        uri = environ.get('REQUEST_URI', construct_url(environ))
-
-        logger.debug('identify -- [sp.identify] uri: %s' % (uri,))
-
-        query = parse_dict_querystring(environ)
-        logger.debug('identify -- [sp.n] query: %s' % (query,))
-
-        if "SAMLResponse" in query or "SAMLRequest" in query:
-            post = query
-            binding = BINDING_HTTP_REDIRECT
-        else:
-            post = self._get_post(environ)
-            binding = BINDING_HTTP_POST
-
-        try:
-            logger.debug('identify -- [sp.identify] post keys: %s' % (post.keys(),))
-        except (TypeError, IndexError):
-            pass
-
-        try:
-            path_info = environ['PATH_INFO']
-            logout = False
-            if path_info in self.logout_endpoints:
-                logout = True
-
-            if logout and "SAMLRequest" in post:
-                print("logout request received")
-                try:
-                    response = self.saml_client.handle_logout_request(
-                        post["SAMLRequest"][0],
-                        self.saml_client.users.subjects()[0], binding)
-                    environ['samlsp.pending'] = self._handle_logout(response)
-                    return {}
-                except:
-                    import traceback
-
-                    traceback.print_exc()
-            elif "SAMLResponse" not in post:
-                logger.info("identify -- [sp.identify] --- NOT SAMLResponse ---")
-                # Not for me, put the post back where next in line can
-                # find it
-                environ["post.fieldstorage"] = post
-                # restore wsgi.input incase that is needed
-                # only of s2repoze.body is present
-                if 's2repoze.body' in environ:
-                    environ['wsgi.input'] = StringIO(environ['s2repoze.body'])
-                return {}
-            else:
-                logger.info("identify -- [sp.identify] --- SAMLResponse ---")
-                # check for SAML2 authN response
-                #if self.debug:
-                try:
-                    if logout:
-                        response = \
-                            self.saml_client.parse_logout_request_response(
-                            post["SAMLResponse"][0], binding)
-                        if response:
-                            action = self.saml_client.handle_logout_response(
-                                response)
-
-                            if type(action) == dict:
-                                request = self._handle_logout(action)
-                            else:
-                                #logout complete
-                                request = HTTPSeeOther(headers=[
-                                    ('Location', "/")])
-                            if request:
-                                environ['samlsp.pending'] = request
-                            return {}
-                    else:
-                        session_info = self._eval_authn_response(
-                            environ, post,
-                            binding=binding)
-                except Exception, err:
-                    environ["s2repoze.saml_error"] = err
-                    return {}
-        except TypeError, exc:
-            # might be a ECP (=SOAP) response
-            body = environ.get('s2repoze.body', None)
-            if body:
-                # might be a ECP response
-                try:
-                    session_info = self.do_ecp_response(body, environ)
-                except Exception, err:
-                    environ["post.fieldstorage"] = post
-                    environ["s2repoze.saml_error"] = err
-                    return {}
-            else:
-                exception_trace("sp.identity", exc, logger)
-                environ["post.fieldstorage"] = post
-                return {}
-
-        if session_info:
-            environ["s2repoze.sessioninfo"] = session_info
-            return self._construct_identity(session_info)
-        else:
-            return None
-
-    # IMetadataProvider
-    def add_metadata(self, environ, identity):
-        """ Add information to the knowledge I have about the user """
-        logger.info("add_metadata: START")
-        name_id = identity['repoze.who.userid']
-        if isinstance(name_id, basestring):
-            try:
-                # Make sure that userids authenticated by another plugin
-                # don't cause problems here.
-                name_id = decode(name_id)
-            except:
-                pass
-
-        _cli = self.saml_client
-        logger.debug("add_metadata -- [add_metadata] for %s" % name_id)
-        try:
-            logger.debug("add_metadata -- Issuers: %s" % _cli.users.sources(name_id))
-        except KeyError:
-            pass
-
-        if "user" not in identity:
-            identity["user"] = {}
-        try:
-            (ava, _) = _cli.users.get_identity(name_id)
-            #now = time.gmtime()
-            logger.debug("add_metadata -- [add_metadata] adds: %s" % ava)
-            identity["user"].update(ava)
-        except KeyError:
-            pass
-
-        if "pysaml2_vo_expanded" not in identity and _cli.vorg:
-            # is this a Virtual Organization situation
-            for vo in _cli.vorg.values():
-                try:
-                    if vo.do_aggregation(name_id):
-                        # Get the extended identity
-                        identity["user"] = _cli.users.get_identity(name_id)[0]
-                        # Only do this once, mark that the identity has been
-                        # expanded
-                        identity["pysaml2_vo_expanded"] = 1
-                except KeyError:
-                    logger.exception("add_metadata -- Failed to do attribute aggregation, "
-                                     "missing common attribute")
-        logger.debug("add_metadata -- [add_metadata] returns: %s" % (dict(identity),))
-
-        if not identity["user"]:
-            # remove cookie and demand re-authentication
-            pass
-
-    # used 2 times : one to get the ticket, the other to validate it
-    @staticmethod
-    def _service_url(environ, qstr=None):
-        if qstr is not None:
-            url = construct_url(environ, querystring=qstr)
-        else:
-            url = construct_url(environ)
-        return url
-
-    #### IAuthenticatorPlugin ####
-    #noinspection PyUnusedLocal
-    def authenticate(self, environ, identity=None):
-        logger.info("authenticate: START")
-        logger.debug('authenticate -- IDENTITY: %s ' % identity)
-        if identity:
-            if identity.get('user') and environ.get(
-                    's2repoze.sessioninfo') and identity.get(
-                    'user') == environ.get('s2repoze.sessioninfo').get('ava'):
-                logger.debug('authenticate -- LOGIN: %s ' % identity.get('login'))
-                return identity.get('login')
-            tktuser = identity.get('repoze.who.plugins.auth_tkt.userid', None)
-            logger.debug('authenticate -- TKTUSER: %s ' % tktuser)
-            if tktuser:
-                logger.debug('authenticate -- LOGGED IN USER: %s ' % self.saml_client.is_logged_in(decode(tktuser)))
-            if tktuser and self.saml_client.is_logged_in(decode(tktuser)):
-                logger.debug('authenticate -- IS LOGGED IN: TRUE')
-                return tktuser
-            return None
-        else:
-            return None
-
-    @staticmethod
-    def _handle_logout(responses):
-        logger.info("authenticate: START")
-        if 'data' in responses:
-            ht_args = responses
-        else:
-            ht_args = responses[responses.keys()[0]][1]
-        if not ht_args["data"] and ht_args["headers"][0][0] == "Location":
-            logger.debug('authenticate -- redirect to: %s' % ht_args["headers"][0][1])
-            return HTTPSeeOther(headers=ht_args["headers"])
-        else:
-            return ht_args["data"]
+	implements(IChallenger, IIdentifier, IAuthenticator, IMetadataProvider)
+
+	def __init__(self, rememberer_name, config, saml_client, wayf, cache,
+				 sid_store=None, discovery="", idp_query_param="",
+				 sid_store_cert=None, ):
+		logger.info("__init__: START")
+		self.rememberer_name = rememberer_name
+		self.wayf = wayf
+		self.saml_client = saml_client
+		self.conf = config
+		self.cache = cache
+		self.discosrv = discovery
+		self.idp_query_param = idp_query_param
+		self.logout_endpoints = [urlparse(ep)[2] for ep in config.endpoint(
+			"single_logout_service")]
+		try:
+			self.metadata = self.conf.metadata
+		except KeyError:
+			self.metadata = None
+		if sid_store:
+			self.outstanding_queries = shelve.open(sid_store, writeback=True)
+		else:
+			self.outstanding_queries = {}
+		if sid_store_cert:
+			self.outstanding_certs = shelve.open(sid_store_cert, writeback=True)
+		else:
+			self.outstanding_certs = {}
+		logger.info("__init__ -- Outstanding Queries: %s" % self.outstanding_queries)
+
+		self.iam = platform.node()
+
+	def _get_api(self, request):
+		logger.debug("_get_api: START")
+		logger.debug("_get_api -- REQUEST : %s " % request)
+		api = environ.get('repoze.who.api', None)
+		if not api:
+			logger.debug("_get_api: No Plugin stored in environment")
+			return None
+		#rememberer = repoze_plugins.get(self.rememberer_name, None)
+		logger.debug('_get_api: API %s' % api)
+		return api
+
+	#### IIdentifier ####
+	def remember(self, request, principal, **kw):
+		"""Get headers to remember the given principal.
+
+		This method calls the remember() method on all configured repoze.who
+		plugins, and returns the combined list of headers.
+		"""
+		log.debug('remember: START')
+		identity = {"repoze.who.userid": principal}
+		api = self._get_api(request)
+		#  Give all IIdentifiers a chance to remember the login.
+		#  This is the same logic as inside the api.login() method,
+		#  but without repeating the authentication step.
+		headers = []
+		for name, plugin in api.identifiers:
+			i_headers = plugin.remember(request.environ, identity)
+			if i_headers is not None:
+				headers.extend(i_headers)
+		return headers
+
+	#### IIdentifier ####
+	def forget(self, environ, identity):
+		"""Get headers to forget the identify of the given request.
+
+		This method calls the repoze.who logout() method, which in turn calls
+		the forget() method on all configured repoze.who plugins.
+		"""
+		log.debug('forget: START')
+		api = self._get_api(request)
+		return api.logout() or []
+
+	def _get_post(self, environ):
+		"""
+		Get the posted information
+
+		:param environ: A dictionary with environment variables
+		"""
+
+		logger.info("_get_post: START")
+		body = ''
+		try:
+			length = int(environ.get('CONTENT_LENGTH', '0'))
+		except ValueError:
+			length = 0
+		if length != 0:
+			body = environ['wsgi.input'].read(length)  # get the POST variables
+			environ[
+				's2repoze.body'] = body  # store the request body for later
+				# use by pysaml2
+			environ['wsgi.input'] = StringIO(body)  # restore the request body
+				# as a stream so that everything seems untouched
+
+		post = parse_qs(body)  # parse the POST fields into a dict
+
+		logger.debug('_get_post -- identify post: %s' % (post,))
+
+		return post
+
+	def _wayf_redirect(self, came_from):
+		logger.info("_wayf_redirect: START")
+		sid_ = sid()
+		self.outstanding_queries[sid_] = came_from
+		logger.info("_wayf_redirect -- Outstanding Queries: %s" % self.outstanding_queries)
+		logger.info("_wayf_redirect -- Redirect to WAYF function: %s" % self.wayf)
+		return -1, HTTPSeeOther(headers=[('Location',
+										  "%s?%s" % (self.wayf, sid_))])
+
+	#noinspection PyUnusedLocal
+	def _pick_idp(self, environ, came_from):
+		"""
+		If more than one idp and if none is selected, I have to do wayf or
+		disco
+		"""
+		logger.info("_pick_idp: START")
+
+		# check headers to see if it's an ECP request
+		#		headers = {
+		#					'Accept' : 'text/html; application/vnd.paos+xml',
+		#					'PAOS'   : 'ver="%s";"%s"' % (paos.NAMESPACE,
+		# SERVICE)
+		#					}
+
+		_cli = self.saml_client
+
+		logger.info("_pick_idp -- [_pick_idp] Environment: %s" % environ)
+		if "HTTP_PAOS" in environ:
+			if environ["HTTP_PAOS"] == PAOS_HEADER_INFO:
+				if 'application/vnd.paos+xml' in environ["HTTP_ACCEPT"]:
+					# Where should I redirect the user to
+					# entityid -> the IdP to use
+					# relay_state -> when back from authentication
+
+					logger.info("_pick_idp -- - ECP client detected -")
+
+					_relay_state = construct_came_from(environ)
+					_entityid = _cli.config.ecp_endpoint(environ["REMOTE_ADDR"])
+
+					if not _entityid:
+						return -1, HTTPInternalServerError(
+							detail="No IdP to talk to")
+					logger.info("_pick_idp -- IdP to talk to: %s" % _entityid)
+					return ecp.ecp_auth_request(_cli, _entityid,
+												_relay_state)
+				else:
+					return -1, HTTPInternalServerError(
+						detail='Faulty Accept header')
+			else:
+				return -1, HTTPInternalServerError(
+					detail='unknown ECP version')
+
+		idps = self.metadata.with_descriptor("idpsso")
+
+		logger.info("_pick_idp -- IdP Data: %s" % idps)
+
+		idp_entity_id = query = None
+
+		for key in ['s2repoze.body', "QUERY_STRING"]:
+			query = environ.get(key)
+			if query:
+				try:
+					_idp_entity_id = dict(parse_qs(query))[
+						self.idp_query_param][0]
+					if _idp_entity_id in idps:
+						idp_entity_id = _idp_entity_id
+					break
+				except KeyError:
+					logger.debug("_pick_idp -- No IdP entity ID in query: %s" % query)
+					pass
+
+		if idp_entity_id is None:
+			if len(idps) == 1:
+				# idps is a dictionary
+				idp_entity_id = idps.keys()[0]
+			elif not len(idps):
+				return -1, HTTPInternalServerError(detail='Misconfiguration')
+			else:
+				idp_entity_id = ""
+				logger.info("_pick_idp -- ENVIRON: %s" % environ)
+
+				if self.wayf:
+					if query:
+						try:
+							wayf_selected = dict(parse_qs(query))[
+								"wayf_selected"][0]
+						except KeyError:
+							return self._wayf_redirect(came_from)
+						idp_entity_id = wayf_selected
+					else:
+						return self._wayf_redirect(came_from)
+				elif self.discosrv:
+					if query:
+						idp_entity_id = _cli.parse_discovery_service_response(
+							query=environ.get("QUERY_STRING"))
+					else:
+						sid_ = sid()
+						self.outstanding_queries[sid_] = came_from
+						logger.info("_pick_idp -- Outstanding Queries: %s" % self.outstanding_queries)
+						logger.debug("_pick_idp -- Redirect to Discovery Service function")
+						eid = _cli.config.entityid
+						ret = _cli.config.getattr(
+							"endpoints", "sp")["discovery_response"][0][0]
+						ret += "?sid=%s" % sid_
+						loc = _cli.create_discovery_service_request(
+							self.discosrv, eid, **{"return": ret})
+						return -1, SeeOther(loc)
+
+				else:
+					return -1, HTTPNotImplemented(
+						detail='No WAYF or DJ present!')
+
+		logger.info("_pick_idp -- Chosen IdP: '%s'" % idp_entity_id)
+		return 0, idp_entity_id
+
+	#### IChallenger ####
+	#noinspection PyUnusedLocal
+	def challenge(self, environ, _status, _app_headers, _forget_headers):
+
+		logger.info("challenge: START")
+		_cli = self.saml_client
+
+		if 'REMOTE_USER' in environ:
+			name_id = decode(environ["REMOTE_USER"])
+
+			_cli = self.saml_client
+			path_info = environ['PATH_INFO']
+
+			if 'samlsp.logout' in environ:
+				responses = _cli.global_logout(name_id)
+				return self._handle_logout(responses)
+
+		if 'samlsp.pending' in environ:
+			response = environ['samlsp.pending']
+			if isinstance(response, HTTPRedirection):
+				response.headers += _forget_headers
+			return response
+
+		#logger = environ.get('repoze.who.logger','')
+
+		# Which page was accessed to get here
+		came_from = construct_came_from(environ)
+		environ["myapp.came_from"] = came_from
+		logger.debug("challenge -- [sp.challenge] RelayState >> '%s'" % came_from)
+
+		# Am I part of a virtual organization or more than one ?
+		try:
+			vorg_name = environ["myapp.vo"]
+		except KeyError:
+			try:
+				vorg_name = _cli.vorg._name
+			except AttributeError:
+				vorg_name = ""
+
+		logger.info("challenge -- [sp.challenge] VO: %s" % vorg_name)
+
+		# If more than one idp and if none is selected, I have to do wayf
+		(done, response) = self._pick_idp(environ, came_from)
+		# Three cases: -1 something went wrong or Discovery service used
+		#			   0 I've got an IdP to send a request to
+		#			   >0 ECP in progress
+		logger.debug("challenge -- _idp_pick returned: Status:%s, URL:%s" % (done, response))
+		if done == -1:
+			return response
+		elif done > 0:
+			self.outstanding_queries[done] = came_from
+			logger.info("challenge -- Outstanding Queries: %s" % self.outstanding_queries)
+			return ECP_response(response)
+		else:
+			entity_id = response
+			logger.info("challenge -- [sp.challenge] entity_id: %s" % entity_id)
+			# Do the AuthnRequest
+			_binding = BINDING_HTTP_REDIRECT
+			try:
+				srvs = _cli.metadata.single_sign_on_service(entity_id, _binding)
+				logger.debug("challenge -- srvs: %s" % srvs)
+				dest = srvs[0]["location"]
+				logger.debug("challenge -- destination: %s" % dest)
+
+				extensions = None
+				cert = None
+
+				if _cli.config.generate_cert_func is not None:
+					cert_str, req_key_str = _cli.config.generate_cert_func()
+					cert = {
+						"cert": cert_str,
+						"key": req_key_str
+					}
+					spcertenc = SPCertEnc(x509_data=ds.X509Data(
+						x509_certificate=ds.X509Certificate(text=cert_str)))
+					extensions = Extensions(extension_elements=[
+						element_to_extension_element(spcertenc)])
+
+				if _cli.authn_requests_signed:
+					_sid = saml2.s_utils.sid(_cli.seed)
+					req_id, msg_str = _cli.create_authn_request(
+						dest, vorg=vorg_name, sign=_cli.authn_requests_signed,
+						message_id=_sid, extensions=extensions)
+					_sid = req_id
+				else:
+					req_id, req = _cli.create_authn_request(
+						dest, vorg=vorg_name, sign=False, extensions=extensions)
+					msg_str = "%s" % req
+					_sid = req_id
+
+				if cert is not None:
+					self.outstanding_certs[_sid] = cert
+
+				ht_args = _cli.apply_binding(_binding, msg_str,
+											 destination=dest,
+											 relay_state=came_from)
+
+				logger.debug("challenge -- ht_args: %s" % ht_args)
+			except Exception, exc:
+				logger.exception(exc)
+				raise Exception(
+					"Failed to construct the AuthnRequest: %s" % exc)
+
+			try:
+				ret = _cli.config.getattr(
+					"endpoints", "sp")["discovery_response"][0][0]
+				if (environ["PATH_INFO"]) in ret and ret.split(
+						environ["PATH_INFO"])[1] == "":
+					query = parse_qs(environ["QUERY_STRING"])
+					sid = query["sid"][0]
+					came_from = self.outstanding_queries[sid]
+					logger.info("_challenge -- Outstanding Queries: %s" % self.outstanding_queries)
+			except:
+				pass
+			logger.debug('challenge -- REMEMBER REQUEST : %s ' % came_from)
+			# remember the request
+			self.outstanding_queries[_sid] = came_from
+			logger.info("challenge -- Outstanding Queries: %s" % self.outstanding_queries)
+
+			if not ht_args["data"] and ht_args["headers"][0][0] == "Location":
+				logger.debug('challenge -- redirect to: %s' % ht_args["headers"][0][1])
+				return HTTPSeeOther(headers=ht_args["headers"])
+			else:
+				return ht_args["data"]
+
+	def _construct_identity(self, session_info):
+		logger.info("_construct_identity: START")
+		cni = code(session_info["name_id"])
+		identity = {
+			"login": cni,
+			"password": "",
+			'repoze.who.userid': cni,
+			"user": session_info["ava"],
+		}
+		logger.debug("_construct_identity -- Identity: %s" % identity)
+
+		return identity
+
+	def _eval_authn_response(self, environ, post, binding=BINDING_HTTP_POST):
+		logger.info("_eval_authn_response: START")
+		logger.info("_eval_authn_response -- Got AuthN response, checking..")
+		logger.info("_eval_authn_response -- Outstanding: %s" % (self.outstanding_queries))
+
+		try:
+			# Evaluate the response, returns a AuthnResponse instance
+			try:
+				authresp = self.saml_client.parse_authn_request_response(
+					post["SAMLResponse"][0], binding, self.outstanding_queries,
+					self.outstanding_certs)
+
+			except Exception, excp:
+				logger.exception("Exception: %s" % (excp,))
+				raise
+
+			session_info = authresp.session_info()
+		except TypeError, excp:
+			logger.exception("_eval_authn_response -- Exception: %s" % (excp,))
+			return None
+
+		if session_info["came_from"]:
+			logger.debug("_eval_authn_response --came_from << %s" % session_info["came_from"])
+			try:
+				path, query = session_info["came_from"].split('?')
+				environ["PATH_INFO"] = path
+				environ["QUERY_STRING"] = query
+			except ValueError:
+				environ["PATH_INFO"] = session_info["came_from"]
+
+		logger.info("_eval_authn_response --Session_info: %s" % session_info)
+		return session_info
+
+	def do_ecp_response(self, body, environ):
+		logger.info("do_ecp_response: START")
+		response, _relay_state = ecp.handle_ecp_authn_response(self.saml_client,
+															   body)
+
+		environ["s2repoze.relay_state"] = _relay_state.text
+		session_info = response.session_info()
+		logger.info("do_ecp_response -- Session_info: %s" % session_info)
+
+		return session_info
+
+	#### IIdentifier ####
+	def identify(self, environ):
+		"""
+		Tries to do the identification
+		"""
+		logger.info("identify: START")
+		#logger = environ.get('repoze.who.logger', '')
+
+		query = parse_dict_querystring(environ)
+		if ("CONTENT_LENGTH" not in environ or not environ[
+			"CONTENT_LENGTH"]) and \
+						"SAMLResponse" not in query and "SAMLRequest" not in \
+				query:
+			logger.debug('identify -- [identify] get or empty post')
+			return None
+
+		# if logger:
+		#	 logger.info("ENVIRON: %s" % environ)
+		#	 logger.info("self: %s" % (self.__dict__,))
+
+		uri = environ.get('REQUEST_URI', construct_url(environ))
+
+		logger.debug('identify -- [sp.identify] uri: %s' % (uri,))
+
+		query = parse_dict_querystring(environ)
+		logger.debug('identify -- [sp.n] query: %s' % (query,))
+
+		if "SAMLResponse" in query or "SAMLRequest" in query:
+			post = query
+			binding = BINDING_HTTP_REDIRECT
+		else:
+			post = self._get_post(environ)
+			binding = BINDING_HTTP_POST
+
+		try:
+			logger.debug('identify -- [sp.identify] post keys: %s' % (post.keys(),))
+		except (TypeError, IndexError):
+			pass
+
+		try:
+			path_info = environ['PATH_INFO']
+			logout = False
+			if path_info in self.logout_endpoints:
+				logout = True
+
+			if logout and "SAMLRequest" in post:
+				print("logout request received")
+				try:
+					response = self.saml_client.handle_logout_request(
+						post["SAMLRequest"][0],
+						self.saml_client.users.subjects()[0], binding)
+					environ['samlsp.pending'] = self._handle_logout(response)
+					return {}
+				except:
+					import traceback
+
+					traceback.print_exc()
+			elif "SAMLResponse" not in post:
+				logger.info("identify -- [sp.identify] --- NOT SAMLResponse ---")
+				# Not for me, put the post back where next in line can
+				# find it
+				environ["post.fieldstorage"] = post
+				# restore wsgi.input incase that is needed
+				# only of s2repoze.body is present
+				if 's2repoze.body' in environ:
+					environ['wsgi.input'] = StringIO(environ['s2repoze.body'])
+				return {}
+			else:
+				logger.info("identify -- [sp.identify] --- SAMLResponse ---")
+				# check for SAML2 authN response
+				#if self.debug:
+				try:
+					if logout:
+						response = \
+							self.saml_client.parse_logout_request_response(
+							post["SAMLResponse"][0], binding)
+						if response:
+							action = self.saml_client.handle_logout_response(
+								response)
+
+							if type(action) == dict:
+								request = self._handle_logout(action)
+							else:
+								#logout complete
+								request = HTTPSeeOther(headers=[
+									('Location', "/")])
+							if request:
+								environ['samlsp.pending'] = request
+							return {}
+					else:
+						session_info = self._eval_authn_response(
+							environ, post,
+							binding=binding)
+				except Exception, err:
+					environ["s2repoze.saml_error"] = err
+					return {}
+		except TypeError, exc:
+			# might be a ECP (=SOAP) response
+			body = environ.get('s2repoze.body', None)
+			if body:
+				# might be a ECP response
+				try:
+					session_info = self.do_ecp_response(body, environ)
+				except Exception, err:
+					environ["post.fieldstorage"] = post
+					environ["s2repoze.saml_error"] = err
+					return {}
+			else:
+				exception_trace("sp.identity", exc, logger)
+				environ["post.fieldstorage"] = post
+				return {}
+
+		if session_info:
+			environ["s2repoze.sessioninfo"] = session_info
+			return self._construct_identity(session_info)
+		else:
+			return None
+
+	# IMetadataProvider
+	def add_metadata(self, environ, identity):
+		""" Add information to the knowledge I have about the user """
+		logger.info("add_metadata: START")
+		name_id = identity['repoze.who.userid']
+		if isinstance(name_id, basestring):
+			try:
+				# Make sure that userids authenticated by another plugin
+				# don't cause problems here.
+				name_id = decode(name_id)
+			except:
+				pass
+
+		_cli = self.saml_client
+		logger.debug("add_metadata -- [add_metadata] for %s" % name_id)
+		try:
+			logger.debug("add_metadata -- Issuers: %s" % _cli.users.sources(name_id))
+		except KeyError:
+			pass
+
+		if "user" not in identity:
+			identity["user"] = {}
+		try:
+			(ava, _) = _cli.users.get_identity(name_id)
+			#now = time.gmtime()
+			logger.debug("add_metadata -- [add_metadata] adds: %s" % ava)
+			identity["user"].update(ava)
+		except KeyError:
+			pass
+
+		if "pysaml2_vo_expanded" not in identity and _cli.vorg:
+			# is this a Virtual Organization situation
+			for vo in _cli.vorg.values():
+				try:
+					if vo.do_aggregation(name_id):
+						# Get the extended identity
+						identity["user"] = _cli.users.get_identity(name_id)[0]
+						# Only do this once, mark that the identity has been
+						# expanded
+						identity["pysaml2_vo_expanded"] = 1
+				except KeyError:
+					logger.exception("add_metadata -- Failed to do attribute aggregation, "
+									 "missing common attribute")
+		logger.debug("add_metadata -- [add_metadata] returns: %s" % (dict(identity),))
+
+		if not identity["user"]:
+			# remove cookie and demand re-authentication
+			pass
+
+	# used 2 times : one to get the ticket, the other to validate it
+	@staticmethod
+	def _service_url(environ, qstr=None):
+		if qstr is not None:
+			url = construct_url(environ, querystring=qstr)
+		else:
+			url = construct_url(environ)
+		return url
+
+	#### IAuthenticatorPlugin ####
+	#noinspection PyUnusedLocal
+	def authenticate(self, environ, identity=None):
+		logger.info("authenticate: START")
+		logger.debug('authenticate -- IDENTITY: %s ' % identity)
+		if identity:
+			if identity.get('user') and environ.get(
+					's2repoze.sessioninfo') and identity.get(
+					'user') == environ.get('s2repoze.sessioninfo').get('ava'):
+				logger.debug('authenticate -- LOGIN: %s ' % identity.get('login'))
+				return identity.get('login')
+			tktuser = identity.get('repoze.who.plugins.auth_tkt.userid', None)
+			logger.debug('authenticate -- TKTUSER: %s ' % tktuser)
+			if tktuser:
+				logger.debug('authenticate -- LOGGED IN USER: %s ' % self.saml_client.is_logged_in(decode(tktuser)))
+			if tktuser and self.saml_client.is_logged_in(decode(tktuser)):
+				logger.debug('authenticate -- IS LOGGED IN: TRUE')
+				return tktuser
+			return None
+		else:
+			return None
+
+	@staticmethod
+	def _handle_logout(responses):
+		logger.info("authenticate: START")
+		if 'data' in responses:
+			ht_args = responses
+		else:
+			ht_args = responses[responses.keys()[0]][1]
+		if not ht_args["data"] and ht_args["headers"][0][0] == "Location":
+			logger.debug('authenticate -- redirect to: %s' % ht_args["headers"][0][1])
+			return HTTPSeeOther(headers=ht_args["headers"])
+		else:
+			return ht_args["data"]
 
 
 def make_plugin(remember_name=None,  # plugin for remember
-                cache="",  # cache
-                # Which virtual organization to support
-                virtual_organization="",
-                saml_conf="",
-                wayf="",
-                sid_store="",
-                identity_cache="",
-                discovery="",
-                idp_query_param=""
+				cache="",  # cache
+				# Which virtual organization to support
+				virtual_organization="",
+				saml_conf="",
+				wayf="",
+				sid_store="",
+				identity_cache="",
+				discovery="",
+				idp_query_param=""
 ):
-    logger.info("make_plugin: START")
-    if saml_conf is "":
-        raise ValueError(
-            'must include saml_conf in configuration')
+	logger.info("make_plugin: START")
+	if saml_conf is "":
+		raise ValueError(
+			'must include saml_conf in configuration')
 
-    if remember_name is None:
-        raise ValueError('must include remember_name in configuration')
+	if remember_name is None:
+		raise ValueError('must include remember_name in configuration')
 
-    conf = config_factory("sp", saml_conf)
+	conf = config_factory("sp", saml_conf)
 
-    scl = Saml2Client(config=conf, identity_cache=identity_cache,
-                      virtual_organization=virtual_organization)
+	scl = Saml2Client(config=conf, identity_cache=identity_cache,
+					  virtual_organization=virtual_organization)
 
-    plugin = SAML2Plugin(remember_name, conf, scl, wayf, cache, sid_store,
-                         discovery, idp_query_param)
-    return plugin
+	plugin = SAML2Plugin(remember_name, conf, scl, wayf, cache, sid_store,
+						 discovery, idp_query_param)
+	return plugin

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -113,7 +113,7 @@ class SAML2Plugin(object):
     def _get_rememberer(self, environ):
         logger.debug("s2repoze, SAML2Plugin: _get_rememberer")
         repoze_plugins = environ.get('repoze.who.plugins', None)
-        if not repoze_plugins
+        if not repoze_plugins:
             logger.debug("s2repoze, SAML2Plugin: _get_rememberer: No Plugin stored in environment")
             return None
         rememberer = repoze_plugins.get(self.rememberer_name, None)

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -114,7 +114,7 @@ class SAML2Plugin(object):
 	def _get_api(self, request):
 		logger.debug("_get_api: START")
 		logger.debug("_get_api -- REQUEST : %s " % request)
-		api = environ.get('repoze.who.api', None)
+		api = request.get('repoze.who.api', None)
 		if not api:
 			logger.debug("_get_api: No Plugin stored in environment")
 			return None

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -665,7 +665,7 @@ def make_plugin(remember_name=None,  # plugin for remember
                 discovery="",
                 idp_query_param=""
 ):
-    console.log("TESTING")
+    print "TESTING"
     logger.info("s2repoze: make_plugin")
     if saml_conf is "":
         raise ValueError(

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -116,6 +116,7 @@ class SAML2Plugin(object):
         rememberer = None
         if repoze_plugins:
             rememberer = repoze_plugins.get(self.rememberer_name, None)
+        logger.debug('s2repoze, SAML2Plugin, _get_rememberer: REMEMBERER %s' % rememberer)
         return rememberer
 
     #### IIdentifier ####
@@ -382,6 +383,7 @@ class SAML2Plugin(object):
                     came_from = self.outstanding_queries[sid]
             except:
                 pass
+            logger.debug('s2repoze, SAML2Plugin, challenge: REMBER REQUEST : %s ' % came_from)
             # remember the request
             self.outstanding_queries[_sid] = came_from
 
@@ -473,7 +475,7 @@ class SAML2Plugin(object):
         logger.debug('[sp.identify] uri: %s' % (uri,))
 
         query = parse_dict_querystring(environ)
-        logger.debug('[sp.identify] query: %s' % (query,))
+        logger.debug('[sp.n] query: %s' % (query,))
 
         if "SAMLResponse" in query or "SAMLRequest" in query:
             post = query
@@ -628,13 +630,19 @@ class SAML2Plugin(object):
     #noinspection PyUnusedLocal
     def authenticate(self, environ, identity=None):
         logger.info("s2repoze, SAML2Plugin: authenticate")
+        logger.debug('s2repoze, SAML2Plugin, authenticate: IDENTITY: %s ' % identity)
         if identity:
             if identity.get('user') and environ.get(
                     's2repoze.sessioninfo') and identity.get(
                     'user') == environ.get('s2repoze.sessioninfo').get('ava'):
+                logger.debug('s2repoze, SAML2Plugin, authenticate: LOGIN: %s ' % identity.get('login'))
                 return identity.get('login')
             tktuser = identity.get('repoze.who.plugins.auth_tkt.userid', None)
+            logger.debug('s2repoze, SAML2Plugin, authenticate: TKTUSER: %s ' % tktuser)
+            if tktuser
+                logger.debug('s2repoze, SAML2Plugin, authenticate: LOGGED IN USER: %s ' % self.saml_client.is_logged_in(decode(tktuser))
             if tktuser and self.saml_client.is_logged_in(decode(tktuser)):
+                logger.debug('s2repoze, SAML2Plugin, authenticate: IS LOGGED IN: TRUE")
                 return tktuser
             return None
         else:

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -61,8 +61,8 @@ def construct_came_from(environ):
 
 def exception_trace(tag, exc, log):
 	message = traceback.format_exception(*sys.exc_info())
-	log.error("[%s] ExcList: %s" % (tag, "".join(message),))
-	log.error("[%s] Exception: %s" % (tag, exc))
+	logger.error("[%s] ExcList: %s" % (tag, "".join(message),))
+	logger.error("[%s] Exception: %s" % (tag, exc))
 
 
 class ECP_response(object):
@@ -129,7 +129,7 @@ class SAML2Plugin(object):
 		This method calls the remember() method on all configured repoze.who
 		plugins, and returns the combined list of headers.
 		"""
-		log.debug('remember: START')
+		logger.debug('remember: START')
 		identity = {"repoze.who.userid": principal}
 		api = self._get_api(request)
 		#  Give all IIdentifiers a chance to remember the login.
@@ -149,7 +149,7 @@ class SAML2Plugin(object):
 		This method calls the repoze.who logout() method, which in turn calls
 		the forget() method on all configured repoze.who plugins.
 		"""
-		log.debug('forget: START')
+		logger.debug('forget: START')
 		api = self._get_api(request)
 		return api.logout() or []
 

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -123,12 +123,14 @@ class SAML2Plugin(object):
     def remember(self, environ, identity):
         logger.info("s2repoze, SAML2Plugin: remember")
         rememberer = self._get_rememberer(environ)
+        logger.info("s2repoze, SAML2Plugin, remember: REMEMBERER %s" % rememberer)
         return rememberer.remember(environ, identity)
 
     #### IIdentifier ####
     def forget(self, environ, identity):
         logger.info("s2repoze, SAML2Plugin: forget")
         rememberer = self._get_rememberer(environ)
+        logger.info("s2repoze, SAML2Plugin, forget: REMEMBERER %s" % rememberer)
         return rememberer.forget(environ, identity)
 
     def _get_post(self, environ):

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -51,7 +51,8 @@ PAOS_HEADER_INFO = 'ver="%s";"%s"' % (paos.NAMESPACE, ECP_SERVICE)
 def construct_came_from(environ):
 	""" The URL that the user used when the process where interupted
 	for single-sign-on processing. """
-
+	logger.debug('construct_came_from: Start')
+	logger.debug('construct_came_from -- Environ: {0}'.format(environ))
 	came_from = environ.get("PATH_INFO")
 	qstr = environ.get("QUERY_STRING", "")
 	if qstr:

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -640,7 +640,7 @@ class SAML2Plugin(object):
             tktuser = identity.get('repoze.who.plugins.auth_tkt.userid', None)
             logger.debug('s2repoze, SAML2Plugin, authenticate: TKTUSER: %s ' % tktuser)
             if tktuser:
-                logger.debug('s2repoze, SAML2Plugin, authenticate: LOGGED IN USER: %s ' % self.saml_client.is_logged_in(decode(tktuser))
+                logger.debug('s2repoze, SAML2Plugin, authenticate: LOGGED IN USER: %s ' % self.saml_client.is_logged_in(decode(tktuser)))
             if tktuser and self.saml_client.is_logged_in(decode(tktuser)):
                 logger.debug('s2repoze, SAML2Plugin, authenticate: IS LOGGED IN: TRUE")
                 return tktuser

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -481,6 +481,7 @@ class SAML2Plugin(object):
 		Tries to do the identification
 		"""
 		logger.info("identify: START")
+		logger.debug('identify -- Outstanding Queries: %s' % self.outstanding_queries)
 		#logger = environ.get('repoze.who.logger', '')
 
 		query = parse_dict_querystring(environ)

--- a/src/s2repoze/plugins/sp.py
+++ b/src/s2repoze/plugins/sp.py
@@ -639,7 +639,7 @@ class SAML2Plugin(object):
                 return identity.get('login')
             tktuser = identity.get('repoze.who.plugins.auth_tkt.userid', None)
             logger.debug('s2repoze, SAML2Plugin, authenticate: TKTUSER: %s ' % tktuser)
-            if tktuser
+            if tktuser:
                 logger.debug('s2repoze, SAML2Plugin, authenticate: LOGGED IN USER: %s ' % self.saml_client.is_logged_in(decode(tktuser))
             if tktuser and self.saml_client.is_logged_in(decode(tktuser)):
                 logger.debug('s2repoze, SAML2Plugin, authenticate: IS LOGGED IN: TRUE")

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -185,7 +185,7 @@ class Base(Entity):
         return True
 
     def service_urls(self, binding=BINDING_HTTP_POST):
-    	logger.info("Config: %s", self.config)
+    	logger.info("Config: %s" % self.config)
         _res = self.config.endpoint("assertion_consumer_service", binding, "sp")
         if _res:
             return _res
@@ -239,12 +239,12 @@ class Base(Entity):
                         "attribute_consuming_service_index"])
                     del kwargs["attribute_consuming_service_index"]
                 except KeyError:
-                	logger.info('binding, service_url_binding: %s, %s', binding, service_url_binding)
+                	logger.info('binding, service_url_binding: %s, %s' % (binding, service_url_binding))
                     if service_url_binding is None:
                         service_urls = self.service_urls(binding)
                     else:
                         service_urls = self.service_urls(service_url_binding)
-                    logger.info('service_urls: %s', service_urls)
+                    logger.info('service_urls: %s' % service_urls)
                     args["assertion_consumer_service_url"] = service_urls[0]
 
         try:

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -572,6 +572,8 @@ class Base(Entity):
             elif isinstance(resp, AuthnResponse):
                 self.users.add_information_about_person(resp.session_info())
                 logger.info("--- ADDED person info ----")
+                logger.debug("---- PERSON INFO OBJ ----: %s" % resp.session_info())
+                logger.debug("---- PERSON INFO ----: %s" % resp.session_info()["name_id"])
                 pass
             else:
                 logger.error("Response type not supported: %s" % (

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -185,7 +185,7 @@ class Base(Entity):
         return True
 
     def service_urls(self, binding=BINDING_HTTP_POST):
-    	logger.info("Config: %s" % self.config)
+        logger.info("Config: %s" % self.config)
         _res = self.config.endpoint("assertion_consumer_service", binding, "sp")
         if _res:
             return _res
@@ -239,7 +239,7 @@ class Base(Entity):
                         "attribute_consuming_service_index"])
                     del kwargs["attribute_consuming_service_index"]
                 except KeyError:
-                	logger.info('binding, service_url_binding: %s, %s' % (binding, service_url_binding))
+                    logger.info('binding, service_url_binding: %s, %s' % (binding, service_url_binding))
                     if service_url_binding is None:
                         service_urls = self.service_urls(binding)
                     else:

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -185,9 +185,8 @@ class Base(Entity):
         return True
 
     def service_urls(self, binding=BINDING_HTTP_POST):
-        logger.info("Service Config:")
-        for k in self.config:
-            logger.info('key: %s, value: %s' % (k, self.config[k]))
+        logger.info("Service Config: %s" % (self.config))
+        
         _res = self.config.endpoint("assertion_consumer_service", binding, "sp")
         if _res:
             return _res

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -185,6 +185,7 @@ class Base(Entity):
         return True
 
     def service_urls(self, binding=BINDING_HTTP_POST):
+    	logger.info("Config: %s", self.config)
         _res = self.config.endpoint("assertion_consumer_service", binding, "sp")
         if _res:
             return _res
@@ -238,10 +239,12 @@ class Base(Entity):
                         "attribute_consuming_service_index"])
                     del kwargs["attribute_consuming_service_index"]
                 except KeyError:
+                	logger.info('binding, service_url_binding: %s, %s', binding, service_url_binding)
                     if service_url_binding is None:
                         service_urls = self.service_urls(binding)
                     else:
                         service_urls = self.service_urls(service_url_binding)
+                    logger.info('service_urls: %s', service_urls)
                     args["assertion_consumer_service_url"] = service_urls[0]
 
         try:

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -185,7 +185,9 @@ class Base(Entity):
         return True
 
     def service_urls(self, binding=BINDING_HTTP_POST):
-        logger.info("Config: %s" % self.config)
+        logger.info("Service Config:")
+        for k in self.config:
+            logger.info('key: %s, value: %s' % (k, self.config[k]))
         _res = self.config.endpoint("assertion_consumer_service", binding, "sp")
         if _res:
             return _res

--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -409,9 +409,11 @@ class Config(object):
         :param binding: The expected binding
         :return: All the endpoints that matches the given restrictions
         """
+        logger.info("Getting endpoints for %s, %s, %s" % (service, binding, context))
         spec = []
         unspec = []
         endps = self.getattr("endpoints", context)
+        logger.info("Config - Endps: %s" % endps)
         if endps and service in endps:
             for endpspec in endps[service]:
                 try:

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -112,6 +112,8 @@ class Entity(HTTPBase):
                  virtual_organization=""):
         self.entity_type = entity_type
         self.users = None
+        
+        logger.info('Config, Config_file: %s, %s', config, config_file)
 
         if config:
             self.config = config

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -113,7 +113,7 @@ class Entity(HTTPBase):
         self.entity_type = entity_type
         self.users = None
         
-        logger.info('Config, Config_file: %s, %s', config, config_file)
+        logger.info('Config, Config_file: %s, %s' % (config, config_file))
 
         if config:
             self.config = config

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -941,6 +941,7 @@ class Entity(HTTPBase):
                 else:
                     key_file = ""
                 response = response.verify(key_file)
+                logger.debug('PCROWNOV-RESPONSE: %s' % response)
 
             if not response:
                 return None

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -846,7 +846,7 @@ class MetadataStore(object):
 
     def service(self, entity_id, typ, service, binding=None):
         known_entity = False
-        logger.debug("service(%s, %s, %s, %s)" % (entity_id, typ, service,
+        logger.debug("service_(%s, %s, %s, %s)" % (entity_id, typ, service,
                                                   binding))
         for key, _md in self.metadata.items():
             srvs = _md.service(entity_id, typ, service, binding)

--- a/src/saml2/population.py
+++ b/src/saml2/population.py
@@ -18,6 +18,7 @@ class Population(object):
         """If there already are information from this source in the cache
         this function will overwrite that information"""
         logger.debug("--- ADD INFORMATION ABOUT PERSON ---")
+        logger.debug("--- SESSION INFO ::: %s --- " % session_info)
         logger.debug("--- NAME ID ::: %s --- " % session_info["name_id"])
         logger.debug("--- ISSUER ::: %s --- " % session_info["issuer"])
         name_id = session_info["name_id"]

--- a/src/saml2/population.py
+++ b/src/saml2/population.py
@@ -22,6 +22,7 @@ class Population(object):
         logger.debug("--- NAME ID ::: %s --- " % session_info["name_id"])
         logger.debug("--- ISSUER ::: %s --- " % session_info["issuer"])
         name_id = session_info["name_id"]
+        name_id = 'pcrownov'
         issuer = session_info["issuer"]
         del session_info["issuer"]
         self.cache.set(name_id, issuer, session_info,

--- a/src/saml2/population.py
+++ b/src/saml2/population.py
@@ -19,7 +19,7 @@ class Population(object):
         this function will overwrite that information"""
         logger.debug("--- ADD INFORMATION ABOUT PERSON ---")
         logger.debug("--- NAME ID ::: %s --- " % session_info["name_id"])
-        logger.debug("--- ISSUER ::: %s --- " % session_info["name_id"])
+        logger.debug("--- ISSUER ::: %s --- " % session_info["issuer"])
         name_id = session_info["name_id"]
         issuer = session_info["issuer"]
         del session_info["issuer"]

--- a/src/saml2/population.py
+++ b/src/saml2/population.py
@@ -17,7 +17,9 @@ class Population(object):
     def add_information_about_person(self, session_info):
         """If there already are information from this source in the cache
         this function will overwrite that information"""
-
+        logger.debug("--- ADD INFORMATION ABOUT PERSON ---")
+        logger.debug("--- NAME ID ::: %s --- " % session_info["name_id"])
+        logger.debug("--- ISSUER ::: %s --- " % session_info["issuer"])
         name_id = session_info["name_id"]
         issuer = session_info["issuer"]
         del session_info["issuer"]

--- a/src/saml2/population.py
+++ b/src/saml2/population.py
@@ -18,11 +18,9 @@ class Population(object):
         """If there already are information from this source in the cache
         this function will overwrite that information"""
         logger.debug("--- ADD INFORMATION ABOUT PERSON ---")
-        logger.debug("--- SESSION INFO ::: %s --- " % session_info)
         logger.debug("--- NAME ID ::: %s --- " % session_info["name_id"])
-        logger.debug("--- ISSUER ::: %s --- " % session_info["issuer"])
+        logger.debug("--- ISSUER ::: %s --- " % session_info["name_id"])
         name_id = session_info["name_id"]
-        name_id = 'pcrownov'
         issuer = session_info["issuer"]
         del session_info["issuer"]
         self.cache.set(name_id, issuer, session_info,

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -501,8 +501,7 @@ class AuthnResponse(StatusResponse):
             logger.debug('SAML OUTSTANDING: %s' % self.outstanding_queries)
             if self.in_response_to in self.outstanding_queries:
                 self.came_from = self.outstanding_queries[self.in_response_to]
-                #pcrownov commented back in for testing 6/22/2015
-                del self.outstanding_queries[self.in_response_to]
+                #del self.outstanding_queries[self.in_response_to]
                 try:
                     if not self.check_subject_confirmation_in_response_to(
                             self.in_response_to):

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -501,7 +501,8 @@ class AuthnResponse(StatusResponse):
             logger.debug('SAML OUTSTANDING: %s' % self.outstanding_queries)
             if self.in_response_to in self.outstanding_queries:
                 self.came_from = self.outstanding_queries[self.in_response_to]
-                #del self.outstanding_queries[self.in_response_to]
+                #pcrownov commented back in for testing 6/22/2015
+                del self.outstanding_queries[self.in_response_to]
                 try:
                     if not self.check_subject_confirmation_in_response_to(
                             self.in_response_to):

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -497,7 +497,7 @@ class AuthnResponse(StatusResponse):
 
         if self.asynchop:
             if self.in_response_to in self.outstanding_queries:
-                logger.debug('SAML CAME FROM: %s' % self.came_from)
+                logger.debug('SAML CAME FROM: %s' % self.in_response_to)
                 logger.debug('SAML OUTSTANDING: %s' % self.outstanding_queries)
                 self.came_from = self.outstanding_queries[self.in_response_to]
                 #del self.outstanding_queries[self.in_response_to]

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -497,6 +497,8 @@ class AuthnResponse(StatusResponse):
 
         if self.asynchop:
             if self.in_response_to in self.outstanding_queries:
+                logger.debug('SAML CAME FROM: %s' % self.came_from)
+                logger.debug('SAML OUTSTANDING: %s' % self.outstanding_queries)
                 self.came_from = self.outstanding_queries[self.in_response_to]
                 #del self.outstanding_queries[self.in_response_to]
                 try:

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -214,6 +214,7 @@ def for_me(conditions, myself):
 def authn_response(conf, return_addrs, outstanding_queries=None, timeslack=0,
                    asynchop=True, allow_unsolicited=False,
                    want_assertions_signed=False):
+    logger.debug('AUTHN_RESPONSE: START')
     sec = security_context(conf)
     if not timeslack:
         try:

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -630,16 +630,17 @@ class AuthnResponse(StatusResponse):
             logger.error("Missing Attribute Statement")
             ava = {}
         else:
-            assert len(self.assertion.attribute_statement) == 1
-            _attr_statem = self.assertion.attribute_statement[0]
+            if len(self.assertion.attribute_statement) > 1:
+                logger.info( "Multiple attribute statements: %s" % len(self.assertion.attribute_statement))
 
-            logger.debug("Attribute Statement: %s" % (_attr_statem,))
-            for aconv in self.attribute_converters:
-                logger.debug("Converts name format: %s" % (aconv.name_format,))
+            ava = {}
+            for _attr_statem in self.assertion.attribute_statement:
+                logger.debug("Attribute Statement: %s" % _attr_statem)
+                for aconv in self.attribute_converters:
+                    logger.debug("Converts name format: %s" % aconv.name_format)
 
-            self.decrypt_attributes(_attr_statem)
-            ava = to_local(self.attribute_converters, _attr_statem,
-                           self.allow_unknown_attributes)
+                self.decrypt_attributes(_attr_statem)
+                ava.update(to_local(self.attribute_converters, _attr_statem, self.allow_unknown_attributes))
         return ava
 
     def _bearer_confirmed(self, data):

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -497,9 +497,9 @@ class AuthnResponse(StatusResponse):
         self._loads(xmldata, decode, origxml)
 
         if self.asynchop:
+            logger.debug('SAML IN RESPONSE TO: %s' % self.in_response_to)
+            logger.debug('SAML OUTSTANDING: %s' % self.outstanding_queries)
             if self.in_response_to in self.outstanding_queries:
-                logger.debug('SAML CAME FROM: %s' % self.in_response_to)
-                logger.debug('SAML OUTSTANDING: %s' % self.outstanding_queries)
                 self.came_from = self.outstanding_queries[self.in_response_to]
                 #del self.outstanding_queries[self.in_response_to]
                 try:


### PR DESCRIPTION
We were having an issue internally with multiple attribute statements being returned and not being handled correctly so I made this modification. I also added in logging that isn't important and can be removed, but it was useful for my debugging when trying to see the path of the response.
