### PR TITLE
Correctly pull the SAMLRequest from Redirect LogoutRequests

### DIFF
--- a/src/saml2/s2repoze/plugins/sp.py
+++ b/src/saml2/s2repoze/plugins/sp.py
@@ -484,9 +484,13 @@ class SAML2Plugin(object):
 
             if logout and "SAMLRequest" in post:
                 print("logout request received")
+                if binding == BINDING_HTTP_REDIRECT:
+                    saml_request = post["SAMLRequest"]
+                else:
+                    saml_request = post["SAMLRequest"][0]
                 try:
                     response = self.saml_client.handle_logout_request(
-                        post["SAMLRequest"][0],
+                        saml_request,
                         self.saml_client.users.subjects()[0], binding)
                     environ['samlsp.pending'] = self._handle_logout(response)
                     return {}


### PR DESCRIPTION
This fixes an issue where SAMLRequest is a key within `post` with a string value, therefore `saml_request = post["SAMLRequest"][0]` returned just the first letter of the SAMLRequest query string parameter. I am assuming that `post` is structured differently because the LogoutRequest uses a Redirect binding and there are different methods for parsing the request.