### PR TITLE
Add config option for specifying SignatureMethod/DigestMethod

### DIFF
--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -119,8 +119,11 @@ class Base(Entity):
             v = self.config.getattr(foo, "sp")
             if v is True or v == 'true':
                 setattr(self, foo, True)
+        for algorithm in ('signing_algorithm', 'digest_algorithm'):
+            setattr(self, algorithm, self.config.getattr(algorithm, "sp"))
 
         self.artifact2response = {}
+
 
     #
     # Private methods

--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -54,7 +54,9 @@ COMMON_ARGS = [
     "validate_certificate",
     "extensions",
     "allow_unknown_attributes",
-    "crypto_backend"
+    "crypto_backend",
+    "signing_algorithm",
+    "digest_algorithm",
 ]
 
 SP_ARGS = [
@@ -219,6 +221,8 @@ class Config(object):
         self.attribute = []
         self.attribute_profile = []
         self.requested_attribute_name_format = NAME_FORMAT_URI
+        self.signing_algorithm = None
+        self.digest_algorithm = None
 
     def setattr(self, context, attr, val):
         if context == "":

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -422,6 +422,12 @@ class Entity(HTTPBase):
 
     def sign(self, msg, mid=None, to_sign=None, sign_prepare=False,
              sign_alg=None, digest_alg=None):
+        if sign_alg is None and self.signing_algorithm:
+            sign_alg = self.signing_algorithm
+
+        if digest_alg is None and self.digest_algorithm:
+            digest_alg = self.digest_algorithm
+
         if msg.signature is None:
             msg.signature = pre_signature_part(msg.id, self.sec.my_cert, 1,
                                                sign_alg=sign_alg,


### PR DESCRIPTION
It would be nice if you were able to specify a default signing or digest method, instead of having to specify it as a parameter to Entity/Saml2Client.sign() and just be able to specify in an sp's config which signing algorithm it is using.

    {
        'service': {
            'sp': {
            'signing_algorithm':  saml2.xmldsig.SIG_RSA_SHA256,
            'name': 'blah',
            ...
           },
       }
    ...
    }
Is there a better method of doing this already in the config that I've missed?



Adds signing_algorithm and digest_algorithm to Entity. 
If `sign_alg` or `digest_alg` is not provided as a parameter to
Saml2Client.sign(), then check if one has been provided in the config
before falling back to `sig_default` in xmldsig.