### PR TITLE
Fix a typo in Saml2Client.do_logout

### DIFF
--- a/src/saml2/client.py
+++ b/src/saml2/client.py
@@ -262,7 +262,7 @@ class Saml2Client(Base):
                                           "entity_ids": entity_ids,
                                           "name_id": code(name_id),
                                           "reason": reason,
-                                          "not_on_of_after": expire,
+                                          "not_on_or_after": expire,
                                           "sign": sign}
 
                     responses[entity_id] = (binding, http_info)


### PR DESCRIPTION
Use "not_on_or_after" instead of "not_on_of_after" for the expiry entry in the state.