### PR TITLE
Address issue #303

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -36,6 +36,7 @@ from saml2 import saml
 from saml2 import extension_elements_to_elements
 from saml2 import SAMLError
 from saml2 import time_util
+from saml2 import xml_util
 
 from saml2.s_utils import RequestVersionTooLow
 from saml2.s_utils import RequestVersionTooHigh
@@ -937,6 +938,7 @@ class AuthnResponse(StatusResponse):
             decr_text_old = None
             while self.find_encrypt_data(resp) and decr_text_old != decr_text:
                 decr_text_old = decr_text
+                decr_text = xml_util.replace_retrieval_method(decr_text)
                 decr_text = self.sec.decrypt_keys(decr_text, keys)
                 resp = samlp.response_from_string(decr_text)
             _enc_assertions = self.decrypt_assertions(resp.encrypted_assertion,
@@ -947,6 +949,7 @@ class AuthnResponse(StatusResponse):
                 _enc_assertions)) and \
                             decr_text_old != decr_text:
                 decr_text_old = decr_text
+                decr_text = xml_util.replace_retrieval_method(decr_text)
                 decr_text = self.sec.decrypt_keys(decr_text, keys)
                 resp = samlp.response_from_string(decr_text)
                 _enc_assertions = self.decrypt_assertions(

--- a/src/saml2/xml_util.py
+++ b/src/saml2/xml_util.py
@@ -1,0 +1,42 @@
+import xml.etree.ElementTree as ET
+
+
+def replace_retrieval_method(xmlstr):
+    """
+    Given an XML string, replace entries of RetrievalMethod with the referred
+    content. Used to support EncryptedKey retrieval method for KeyInfo in
+    encrypted assertions.
+    """
+    root = ET.fromstring(xmlstr)
+    ds_ns = 'http://www.w3.org/2000/09/xmldsig#'
+    xenc_ns = 'http://www.w3.org/2001/04/xmlenc#'
+    retrieval_methods = root.findall('.//{{{}}}RetrievalMethod'.format(ds_ns))
+    replacements = []
+    for retmet in retrieval_methods:
+        if (retmet.attrib['Type'] !=
+                'http://www.w3.org/2001/04/xmlenc#EncryptedKey'):
+            # Unsupported
+            continue
+        uri = retmet.attrib['URI']
+        if not uri.startswith('#'):
+            # Unsupported
+            continue
+        encrypted_key = \
+            root.findall(
+                './/{{{}}}EncryptedKey[@Id="{}"]'.format(xenc_ns, uri[1:]))
+        if len(encrypted_key) != 1:
+            # Unsupported
+            continue
+        replacements.append((retmet, encrypted_key[0]))
+
+    parent_map = {c: p for p in root.iter() for c in p}
+    for old, new in replacements:
+        parent = parent_map[old]
+        parent_index = list(parent).index(old)
+        parent.remove(old)
+        parent.insert(parent_index, new)
+    # now remove the referenced keys from the original position
+    for _, new in replacements:
+        parent = parent_map[new]
+        parent.remove(new)
+    return ET.tostring(root)


### PR DESCRIPTION
Hello!

As described in https://github.com/rohe/pysaml2/issues/303, `pysaml2` (more specifically `xmlsec`) does not appear to be able to handle the case when the `EncryptedKey` node lives outside of the `EncryptedData` node and is referenced via a `RetrievalMethod`. We encountered this case when trying to test out Okta with encrypted assertions, as Okta returns an encrypted assertion in this format (example below).

We worked around this in this PR by having a routine using `lxml` that will do the replacement, and injecting that routine before attempting a decryption.

Please let me know if there is anything you don't like and what I need to do to get this merged upstream.


Many thanks for this useful library and feedback!


```xml
<?xml version="1.0" encoding="UTF-8"?>
<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" Destination="http://localhost:8002/saml2/acs/" ID="id11761241389251722145902058" InResponseTo="id-RitDIK0Rw9cPswXB7" IssueInstant="2017-09-22T23:44:48.049Z" Version="2.0">
   <saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">http://www.okta.com/exk9ithoa28JZW9d30h7</saml:Issuer>
   <ds:Signature>
      <ds:SignedInfo>
         <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
         <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
         <ds:Reference URI="#id11761241389251722145902058">
            <ds:Transforms>
               <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
               <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
            </ds:Transforms>
            <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
            <ds:DigestValue>Qn5+3E/sUjLKOfgWY1wV5ihLMJ3TMSsY7Kc/CuItkIQ=</ds:DigestValue>
         </ds:Reference>
      </ds:SignedInfo>
      <ds:SignatureValue> ... snipped ... </ds:SignatureValue>
      <ds:KeyInfo>
         <ds:X509Data>
            <ds:X509Certificate> ... snipped ... </ds:X509Certificate>
         </ds:X509Data>
      </ds:KeyInfo>
   </ds:Signature>
   <samlp:Status>
      <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
   </samlp:Status>
   <saml:EncryptedAssertion>
      <xenc:EncryptedData Id="_b5d6586faa6fae5089c31e3f4401a9f0" Type="http://www.w3.org/2001/04/xmlenc#Element">
         <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc" />
         <ds:KeyInfo>
            <ds:RetrievalMethod Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey" URI="#_c531e2cfbfabc1fb5eea414615d24826" />
         </ds:KeyInfo>
         <xenc:CipherData>
            <xenc:CipherValue> ... snipped .. .</xenc:CipherValue>
         </xenc:CipherData>
      </xenc:EncryptedData>
      <xenc:EncryptedKey Id="_c531e2cfbfabc1fb5eea414615d24826">
         <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p">
            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
         </xenc:EncryptionMethod>
         <ds:KeyInfo>
            <ds:X509Data>
               <ds:X509Certificate> ... snipped ... </ds:X509Certificate>
            </ds:X509Data>
         </ds:KeyInfo>
         <xenc:CipherData>
            <xenc:CipherValue> ... snipped ... </xenc:CipherValue>
         </xenc:CipherData>
         <xenc:ReferenceList>
            <xenc:DataReference URI="#_b5d6586faa6fae5089c31e3f4401a9f0" />
         </xenc:ReferenceList>
      </xenc:EncryptedKey>
   </saml:EncryptedAssertion>
</samlp:Response>
```