### PR TITLE
Strip trailing mdq slash

### DIFF
--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -794,7 +794,7 @@ class MetaDataMDX(InMemoryMetaData):
         sha1 transformation.
         """
         super(MetaDataMDX, self).__init__(None, '')
-        self.url = url
+        self.url = url.rstrip('/')
 
         if entity_transform:
             self.entity_transform = entity_transform


### PR DESCRIPTION
Having been bitten by trailing slash errors while configuring mdq I thought it'd be nice to protect others from such a frustrating typo.