### PR TITLE
Fix for NameID and Unicode literals (KeyError in urllib.quote)

### DIFF
--- a/src/saml2/ident.py
+++ b/src/saml2/ident.py
@@ -41,7 +41,7 @@ def code(item):
     for attr in ATTR:
         val = getattr(item, attr)
         if val:
-            _res.append("%d=%s" % (i, quote(val)))
+            _res.append("%d=%s" % (i, quote(val.encode('utf-8'))))
         i += 1
     return ",".join(_res)
 
@@ -66,7 +66,7 @@ def decode(txt):
         if part.find("=") != -1:
             i, val = part.split("=")
             try:
-                setattr(_nid, ATTR[int(i)], unquote(val))
+                setattr(_nid, ATTR[int(i)], unquote(val.decode('utf-8')))
             except:
                 pass
     return _nid


### PR DESCRIPTION
Fixes `KeyError: u'\xe9'` when "saml2:NameID" contains Unicode literals.
Exception traceback:
 
```
 File "djangosaml2/views.py", line 260, in assertion_consumer_service
    response = client.parse_authn_request_response(xmlstr, BINDING_HTTP_POST, outstanding_queries)
  File "saml2/client_base.py", line 612, in parse_authn_request_response
    self.users.add_information_about_person(resp.session_info())
  File "saml2/population.py", line 27, in add_information_about_person
    session_info["not_on_or_after"])
  File "saml2/cache.py", line 120, in set
    info['name_id'] = code(name_id)
  File "saml2/ident.py", line 44, in code
    _res.append("%d=%s" % (i, quote(val)))
  File "python2.7/urllib.py", line 1298, in quote
    return ''.join(map(quoter, s))
```

Closes #494