### PR TITLE
Added parameter to config list in order to be able to set authn_reque…

### DIFF
--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -66,6 +66,7 @@ SP_ARGS = [
     "want_response_signed",
     "want_assertions_signed",
     "authn_requests_signed",
+    "authn_requests_signed_alg",
     "name_form",
     "endpoints",
     "ui_info",


### PR DESCRIPTION
Added parameter to config list in order to be able to set authn_requests_signed using sha256 (particularly from djangosaml2)

When configuring (e.g. from djangosaml2) the parameter
`
    'authn_requests_signed': True,
`
works OK, whereas 
`
    'authn_requests_signed_alg': 'sha256'
`
does not work because the parameter is not in the list of allowed parameters (SP_ARGS). As far as I know, there is no other way to set sha-256 algorithm from config without this small change in the code.

The solution is a one-liner that adds 'authn_requests_signed_alg' to SP_ARGS list of parameters in src/saml2/config.py right below 'authn_requests_signed'


### All Submissions:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



