### PR TITLE
No relay state

### DIFF
--- a/src/saml2/pack.py
+++ b/src/saml2/pack.py
@@ -94,10 +94,12 @@ def http_form_post_message(message, location, relay_state="",
             val=html.escape(_msg),
             type='hidden')
 
-    relay_state_input = HTML_INPUT_ELEMENT_SPEC.format(
-            name='RelayState',
-            val=html.escape(relay_state),
-            type='hidden')
+    relay_state_input = ""
+    if relay_state:
+        relay_state_input = HTML_INPUT_ELEMENT_SPEC.format(
+                name='RelayState',
+                val=html.escape(relay_state),
+                type='hidden')
 
     response = HTML_FORM_SPEC.format(
         saml_response_input=saml_response_input,

--- a/src/saml2/pack.py
+++ b/src/saml2/pack.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-#
-
 """Contains classes and functions that are necessary to implement
 different bindings.
 
@@ -10,24 +6,21 @@ Bindings normally consists of three parts:
 - how to package the information
 - which protocol to use
 """
-import html
-from six.moves.urllib.parse import urlparse, urlencode
-import saml2
+
 import base64
-from saml2.s_utils import deflate_and_base64_encode
-from saml2.s_utils import Unsupported
+import html
 import logging
-from saml2.sigver import REQ_ORDER
-from saml2.sigver import RESP_ORDER
-from saml2.sigver import SIGNER_ALGS
-import six
+
+import saml2
+from saml2.s_utils import deflate_and_base64_encode
+from saml2.sigver import REQ_ORDER, RESP_ORDER
 from saml2.xmldsig import SIG_ALLOWED_ALG
 
-logger = logging.getLogger(__name__)
+import six
+from six.moves.urllib.parse import urlencode, urlparse
 
 try:
     from xml.etree import cElementTree as ElementTree
-
     if ElementTree.VERSION < '1.3.0':
         # cElementTree has no support for register_namespace
         # neither _namespace_map, thus we sacrify performance
@@ -39,6 +32,9 @@ except ImportError:
     except ImportError:
         from elementtree import ElementTree
 import defusedxml.ElementTree
+
+
+logger = logging.getLogger(__name__)
 
 NAMESPACE = "http://schemas.xmlsoap.org/soap/envelope/"
 
@@ -66,6 +62,7 @@ HTML_FORM_SPEC = """<!DOCTYPE html>
     </form>
   </body>
 </html>"""
+
 
 def http_form_post_message(message, location, relay_state="",
                            typ="SAMLRequest", **kwargs):
@@ -107,6 +104,7 @@ def http_form_post_message(message, location, relay_state="",
         action=location)
 
     return {"headers": [("Content-type", "text/html")], "data": response}
+
 
 def http_post_message(message, relay_state="", typ="SAMLRequest", **kwargs):
     """
@@ -273,7 +271,8 @@ def parse_soap_enveloped_saml(text, body_class, header_class=None):
         if part.tag == '{%s}Body' % NAMESPACE:
             for sub in part:
                 try:
-                    body = saml2.create_class_from_element_tree(body_class, sub)
+                    body = saml2.create_class_from_element_tree(
+                            body_class, sub)
                 except Exception:
                     raise Exception(
                         "Wrong body type (%s) in SOAP envelope" % sub.tag)

--- a/tests/test_89_http_post_relay_state.py
+++ b/tests/test_89_http_post_relay_state.py
@@ -1,0 +1,100 @@
+from contextlib import closing
+from saml2 import BINDING_HTTP_POST
+from saml2.client import Saml2Client
+from saml2.server import Server
+
+import sys
+if sys.version_info.major < 3:
+    from HTMLParser import HTMLParser
+else:
+    from html.parser import HTMLParser
+
+# Typical RelayState used by Shibboleth SP.
+SHIB_SP_RELAY_STATE = """\
+ss:mem:ab1e6a31f3bd040ffd1d64a2d0e15d61ce517f5e1a94a41ea4fae32cc8d70a04"""
+
+
+class RelayStateHTMLParser(HTMLParser, object):
+    """Class used to parse HTML from a HTTP-POST binding response
+        and determine if the HTML includes the expected relay state."""
+    def __init__(self, expected_relay_state):
+        super(RelayStateHTMLParser, self).__init__()
+
+        self.expected_relay_state = expected_relay_state
+        self.expected_relay_state_found = False
+        self.input_relay_state_element_found = False
+
+    def handle_starttag(self, tag, attrs):
+        """If the <input> tag is found and it includes the correct value
+        for the relay state set the relay state found flag to true."""
+        if tag == 'input':
+            if ('name', 'RelayState') in attrs:
+                self.input_relay_state_found = True
+                if ('value', self.expected_relay_state) in attrs:
+                    self.expected_relay_state_found = True
+
+
+def test_relay_state():
+    # Identity information about a mock user.
+    identity = {
+        "eduPersonEntitlement": "Short stop",
+        "surName": "Jeter",
+        "givenName": "Derek",
+        "mail": "derek.jeter@nyy.mlb.com",
+        "title": "The man"
+        }
+
+    # Create a service provider using the servera_conf.py configuration.
+    sp = Saml2Client(config_file="servera_conf")
+
+    # Create an identity providver using the idp_all_conf.py configuration.
+    with closing(Server(config_file="idp_all_conf")) as idp:
+        # Create a response to an authentication request as if
+        # it came from the SP.
+
+        name_id = idp.ident.transient_nameid(sp.config.entityid, "id12")
+        binding, destination = idp.pick_binding("assertion_consumer_service",
+                                                bindings=[BINDING_HTTP_POST],
+                                                entity_id=sp.config.entityid)
+        resp = idp.create_authn_response(identity,
+                                         "id-123456789",
+                                         destination,
+                                         sp.config.entityid,
+                                         name_id=name_id)
+
+        # Apply the HTTP_POST binding to the response with a relay state
+        # typical from a Shibboleth SP to create the HTML that carries
+        # the SAML response.
+        relay_state = SHIB_SP_RELAY_STATE
+        html = idp.apply_binding(BINDING_HTTP_POST,
+                                 "%s" % resp, destination, relay_state)['data']
+
+        # Parse the HTML and verify that it contains the correct relay state.
+        parser = RelayStateHTMLParser(relay_state)
+        parser.feed(html)
+        assert parser.expected_relay_state_found
+
+        # Apply the HTTP_POST binding to the response with relay state None.
+        relay_state = None
+        html = idp.apply_binding(BINDING_HTTP_POST,
+                                 "%s" % resp, destination, relay_state)['data']
+
+        # Parse the HTML and verify that it does not contain a relay state.
+        parser = RelayStateHTMLParser(relay_state)
+        parser.feed(html)
+        assert not parser.input_relay_state_element_found
+
+        # Apply the HTTP_POST binding to the response with empty
+        # string relay state.
+        relay_state = ""
+        html = idp.apply_binding(BINDING_HTTP_POST,
+                                 "%s" % resp, destination, relay_state)['data']
+
+        # Parse the HTML and verify that it does not contain a relay state.
+        parser = RelayStateHTMLParser(relay_state)
+        parser.feed(html)
+        assert not parser.input_relay_state_element_found
+
+
+if __name__ == "__main__":
+    test_relay_state()


### PR DESCRIPTION
If an authentication request does not include a RelayState when the SAML response is generated for the HTTP-POST binding the HTML that carries the response includes a non-conformant RelayState value of "None". This pull request fixes that behavior so that if there is no RelayState then no RelayState is included in the HTML carrying the HTTP-POST binding response.

The change is to break up the string template used to create the HTML so that a test can be done and if the RelayState is None or empty string ("") then the RelayState parameter is not included at all. This solves the issue but keeps the details of how the SAML response is converted to the HTML binding in one place.

New tests have been added in test_89_http_post_relay_state.py to not only test that if there is no RelayState or it is empty then no RelayState is include in the HTML, but also to test that if there is a RelayState then the HTML includes it correctly.

This pull request passes all tests for both python2 and python3.

I have run the source file affected and the new test file through flake8 and have made the necessary changes so that it meets PEP8.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



