### PR TITLE
Fix error while parsing LogoutResponse message

### DIFF
--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -1179,8 +1179,13 @@ class Entity(HTTPBase):
     # ------------------------------------------------------------------------
 
     def parse_logout_request_response(self, xmlstr, binding=BINDING_SOAP):
+        kwargs = None
+        if xmlstr:
+            kwargs = {
+                "return_addrs": self.config.endpoint("single_logout_service", binding, "sp")
+            }
         return self._parse_response(xmlstr, LogoutResponse,
-                                    "single_logout_service", binding)
+                                    "single_logout_service", binding, **kwargs)
 
     # ------------------------------------------------------------------------
 


### PR DESCRIPTION
The details of the issue are described in #504

Explicitly setting `kwargs['return_addrs']` before invoking `parse_response` method on receiving `LogoutResponse` message. 

I do see that there is business logic to try and attempt to set the value of `kwargs["return_addrs"]` [here](https://github.com/ksshetty/pysaml2/blob/master/src/saml2/entity.py#L1120). However, I believe this will not work as we're not passing in the context here. Therefore, rather than fix the logic inside the `parse_response` method (which is widely used), I decided to make the change specific to parsing of the `LogoutResponse`. 

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


