### PR TITLE
Explicitly forbid DTDs when parsing XML

### DIFF
--- a/src/saml2/__init__.py
+++ b/src/saml2/__init__.py
@@ -88,7 +88,7 @@ def create_class_from_xml_string(target_class, xml_string):
     """
     if not isinstance(xml_string, six.binary_type):
         xml_string = xml_string.encode('utf-8')
-    tree = defusedxml.ElementTree.fromstring(xml_string)
+    tree = defusedxml.ElementTree.fromstring(xml_string, forbid_dtd=True)
     return create_class_from_element_tree(target_class, tree)
 
 
@@ -270,7 +270,7 @@ class ExtensionElement(object):
 
 
 def extension_element_from_string(xml_string):
-    element_tree = defusedxml.ElementTree.fromstring(xml_string)
+    element_tree = defusedxml.ElementTree.fromstring(xml_string, forbid_dtd=True)
     return _extension_element_from_element_tree(element_tree)
 
 

--- a/src/saml2/pack.py
+++ b/src/saml2/pack.py
@@ -260,7 +260,7 @@ def parse_soap_enveloped_saml(text, body_class, header_class=None):
     :param text: The SOAP object as XML
     :return: header parts and body as saml.samlbase instances
     """
-    envelope = defusedxml.ElementTree.fromstring(text)
+    envelope = defusedxml.ElementTree.fromstring(text, forbid_dtd=True)
     assert envelope.tag == '{%s}Envelope' % NAMESPACE
 
     # print(len(envelope))

--- a/src/saml2/soap.py
+++ b/src/saml2/soap.py
@@ -134,7 +134,7 @@ def parse_soap_enveloped_saml_thingy(text, expected_tags):
     :param expected_tags: What the tag of the SAML thingy is expected to be.
     :return: SAML thingy as a string
     """
-    envelope = defusedxml.ElementTree.fromstring(text)
+    envelope = defusedxml.ElementTree.fromstring(text, forbid_dtd=True)
 
     # Make sure it's a SOAP message
     assert envelope.tag == '{%s}Envelope' % soapenv.NAMESPACE
@@ -184,7 +184,7 @@ def class_instances_from_soap_enveloped_saml_thingies(text, modules):
     :return: The body and headers as class instances
     """
     try:
-        envelope = defusedxml.ElementTree.fromstring(text)
+        envelope = defusedxml.ElementTree.fromstring(text, forbid_dtd=True)
     except Exception as exc:
         raise XmlParseError("%s" % exc)
 
@@ -210,7 +210,7 @@ def open_soap_envelope(text):
     :return: dictionary with two keys "body"/"header"
     """
     try:
-        envelope = defusedxml.ElementTree.fromstring(text)
+        envelope = defusedxml.ElementTree.fromstring(text, forbid_dtd=True)
     except Exception as exc:
         raise XmlParseError("%s" % exc)
 


### PR DESCRIPTION
Protect pysaml2 users with insecure underlying XML libraries by
explicitly forbidding DTD in incoming XML SAML messages.

Not sure if this can be reliably tested (because of dependency in
undelying xml libraries
Resolves #508

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



