### PR TITLE
Fix example dependencies

### DIFF
--- a/src/saml2/aes.py
+++ b/src/saml2/aes.py
@@ -1,26 +1,23 @@
-#!/usr/bin/env python
 import os
-from base64 import b64encode
 from base64 import b64decode
+from base64 import b64encode
 
 from Cryptodome import Random
 from Cryptodome.Cipher import AES
 
-__author__ = 'rolandh'
 
 POSTFIX_MODE = {
-    "cbc": AES.MODE_CBC,
-    "cfb": AES.MODE_CFB,
-    "ecb": AES.MODE_CFB,
+    'cbc': AES.MODE_CBC,
+    'cfb': AES.MODE_CFB,
+    'ecb': AES.MODE_CFB,
 }
 
 BLOCK_SIZE = 16
 
 
 class AESCipher(object):
-    def __init__(self, key, iv=""):
+    def __init__(self, key, iv=None):
         """
-
         :param key: The encryption key
         :param iv: Init vector
         :return: AESCipher instance
@@ -28,36 +25,34 @@ class AESCipher(object):
         self.key = key
         self.iv = iv
 
-    def build_cipher(self, iv="", alg="aes_128_cbc"):
+    def build_cipher(self, iv=None, alg='aes_128_cbc'):
         """
         :param iv: init vector
         :param alg: cipher algorithm
         :return: A Cipher instance
         """
-        typ, bits, cmode = alg.split("_")
+        typ, bits, cmode = alg.split('_')
 
         if not iv:
-            if self.iv:
-                iv = self.iv
-            else:
-                iv = Random.new().read(AES.block_size)
-        else:
-            assert len(iv) == AES.block_size
+            iv = self.iv if self.iv else Random.new().read(AES.block_size)
 
-        if bits not in ["128", "192", "256"]:
-            raise Exception("Unsupported key length")
-        try:
-            assert len(self.key) == int(bits) >> 3
-        except AssertionError:
-            raise Exception("Wrong Key length")
+        if len(iv) != AES.block_size:
+            raise Exception('Wrong iv size')
+
+        if bits not in ['128', '192', '256']:
+            raise Exception('Unsupported key length')
+
+        if len(self.key) != int(bits) >> 3:
+            raise Exception('Wrong Key length')
 
         try:
-            return AES.new(self.key, POSTFIX_MODE[cmode], iv), iv
+            result = AES.new(self.key, POSTFIX_MODE[cmode], iv)
         except KeyError:
-            raise Exception("Unsupported chaining mode")
+            raise Exception('Unsupported chaining mode')
+        else:
+            return result, iv
 
-
-    def encrypt(self, msg, iv=None, alg="aes_128_cbc", padding="PKCS#7",
+    def encrypt(self, msg, iv=None, alg='aes_128_cbc', padding='PKCS#7',
                 b64enc=True, block_size=BLOCK_SIZE):
         """
         :param key: The encryption key
@@ -69,9 +64,9 @@ class AESCipher(object):
         :return: The encrypted message
         """
 
-        if padding == "PKCS#7":
+        if padding == 'PKCS#7':
             _block_size = block_size
-        elif padding == "PKCS#5":
+        elif padding == 'PKCS#5':
             _block_size = 8
         else:
             _block_size = 0
@@ -79,41 +74,42 @@ class AESCipher(object):
         if _block_size:
             plen = _block_size - (len(msg) % _block_size)
             c = chr(plen)
-            msg += c*plen
+            msg += c * plen
 
         cipher, iv = self.build_cipher(iv, alg)
         cmsg = iv + cipher.encrypt(msg)
+
         if b64enc:
-            return b64encode(cmsg)
+            enc_msg = b64encode(cmsg)
         else:
-            return cmsg
+            enc_msg = cmsg
 
+        return enc_msg
 
-    def decrypt(self, msg, iv=None, alg="aes_128_cbc", padding="PKCS#7", b64dec=True):
+    def decrypt(self, msg, iv=None, alg='aes_128_cbc', padding='PKCS#7',
+                b64dec=True):
         """
         :param key: The encryption key
         :param iv: init vector
         :param msg: Base64 encoded message to be decrypted
         :return: The decrypted message
         """
-        if b64dec:
-            data = b64decode(msg)
-        else:
-            data = msg
+        data = b64decode(msg) if b64dec else msg
 
         _iv = data[:AES.block_size]
         if iv:
             assert iv == _iv
         cipher, iv = self.build_cipher(iv, alg=alg)
         res = cipher.decrypt(data)[AES.block_size:]
-        if padding in ["PKCS#5", "PKCS#7"]:
+        if padding in ['PKCS#5', 'PKCS#7']:
             res = res[:-ord(res[-1])]
         return res
 
-if __name__ == "__main__":
-    key_ = "1234523451234545"  # 16 byte key
+
+if __name__ == '__main__':
+    key_ = '1234523451234545'  # 16 byte key
     # Iff padded, the message doesn't have to be multiple of 16 in length
-    msg_ = "ToBeOrNotTobe W.S."
+    msg_ = 'ToBeOrNotTobe W.S.'
     aes = AESCipher(key_)
     iv_ = os.urandom(16)
     encrypted_msg = aes.encrypt(key_, msg_, iv_)

--- a/src/saml2/authn.py
+++ b/src/saml2/authn.py
@@ -120,7 +120,7 @@ class UsernamePasswordMako(UserAuthnMethod):
         self.return_to = return_to
         self.active = {}
         self.query_param = "upm_answer"
-        self.aes = AESCipher(self.srv.symkey, srv.iv)
+        self.aes = AESCipher(self.srv.symkey.encode(), srv.iv)
 
     def __call__(self, cookie=None, policy_url=None, logo_url=None,
                  query="", **kwargs):
@@ -171,7 +171,8 @@ class UsernamePasswordMako(UserAuthnMethod):
         try:
             self._verify(_dict["password"][0], _dict["login"][0])
             timestamp = str(int(time.mktime(time.gmtime())))
-            info = self.aes.encrypt("::".join([_dict["login"][0], timestamp]))
+            msg = "::".join([_dict["login"][0], timestamp])
+            info = self.aes.encrypt(msg.encode())
             self.active[info] = timestamp
             cookie = make_cookie(self.cookie_name, info, self.srv.seed)
             return_to = create_return_url(self.return_to, _dict["query"][0],
@@ -191,7 +192,8 @@ class UsernamePasswordMako(UserAuthnMethod):
                 info, timestamp = parse_cookie(self.cookie_name,
                                                self.srv.seed, cookie)
                 if self.active[info] == timestamp:
-                    uid, _ts = self.aes.decrypt(info).split("::")
+                    msg = self.aes.decrypt(info).decode()
+                    uid, _ts = msg.split("::")
                     if timestamp == _ts:
                         return {"uid": uid}
             except Exception:


### PR DESCRIPTION
This is related to #389 and afdf5b4a8cca33dbe746095d9442b958c5fa9a24.

Commit afdf5b4a8cca33dbe746095d9442b958c5fa9a24 tried to _Swap pycrypto* for pyca/cryptography_.

> pyOpenSSL is already a dependency and pyOpenSSL uses cryptography.
> This also reduces the complexity of the code significantly in several
> places (and removes the need to directly manipulate asn1). A future
> PR could remove pyOpenSSL entirely as all the cert behavior is supported
> directly by cryptography.

This work was not complete as `aes.py` was still using the Cryptodome library to implement a wrapper around AES.

This changeset completes the work started with afdf5b4a8cca33dbe746095d9442b958c5fa9a24 and replaces Cryptodome for cryptography. The changes make sure that the test case passes for both python2 and python3.

The assumption is made that `AESCipher` class accepts only `byte` input. Users of `AESCipher` are responsible to make sure that the arguments are given with the correct type.


### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



