### PR TITLE
Remove unnecessary dependency on pytz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ install_requires = [
     'requests >= 1.0.0',
     'future',
     'cryptography',
-    'pytz',
     'pyOpenSSL',
     'python-dateutil',
     'defusedxml',

--- a/src/saml2/cert.py
+++ b/src/saml2/cert.py
@@ -3,7 +3,7 @@ __author__ = 'haho0032'
 import base64
 import datetime
 import dateutil.parser
-import pytz
+import dateutil.tz
 import six
 from OpenSSL import crypto
 from os.path import join
@@ -290,7 +290,7 @@ class OpenSSLWrapper(object):
 
     def certificate_not_valid_yet(self, cert):
         starts_to_be_valid = dateutil.parser.parse(cert.get_notBefore())
-        now = pytz.UTC.localize(datetime.datetime.utcnow())
+        now = datetime.datetime.now(dateutil.tz.tzutc())
         if starts_to_be_valid < now:
             return False
         return True


### PR DESCRIPTION
`dateutil` (already a dependency) provides a `UTC` object, so there's no need for a `pytz` dependency.

This also drops the use of `datetime.utcnow` in favor of the preferred `datetime.now(some_tzinfo)`, what is being done now is effectively the equivalent of: `datetime.now(UTC).replace(tzinfo=None).replace(tzinfo=UTC)`. `utcnow` is a relic from before the `tz` argument was added to `datetime.now`.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* **N/A** Have you written new tests for your changes? (Covered by existing tests)
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



