### PR TITLE
Fix AES IV reuse - drop support for CTR and ECB - address CVE-2017-1000246

### DIFF
--- a/src/saml2/aes.py
+++ b/src/saml2/aes.py
@@ -103,27 +103,3 @@ class AESCipher(object):
             idx = bytearray(res)[-1]
             res = res[:-idx]
         return res
-
-
-def run_test():
-    key = b'1234523451234545'  # 16 byte key
-    # Iff padded, the message doesn't have to be multiple of 16 in length
-    original_msg = b'ToBeOrNotTobe W.S.'
-    aes = AESCipher(key)
-
-    encrypted_msg = aes.encrypt(original_msg)
-    decrypted_msg = aes.decrypt(encrypted_msg)
-    assert decrypted_msg == original_msg
-
-    encrypted_msg = aes.encrypt(original_msg)
-    decrypted_msg = aes.decrypt(encrypted_msg)
-    assert decrypted_msg == original_msg
-
-    aes = AESCipher(key)
-    encrypted_msg = aes.encrypt(original_msg)
-    decrypted_msg = aes.decrypt(encrypted_msg)
-    assert decrypted_msg == original_msg
-
-
-if __name__ == '__main__':
-    run_test()

--- a/src/saml2/authn.py
+++ b/src/saml2/authn.py
@@ -120,7 +120,7 @@ class UsernamePasswordMako(UserAuthnMethod):
         self.return_to = return_to
         self.active = {}
         self.query_param = "upm_answer"
-        self.aes = AESCipher(self.srv.symkey.encode(), srv.iv)
+        self.aes = AESCipher(self.srv.symkey.encode())
 
     def __call__(self, cookie=None, policy_url=None, logo_url=None,
                  query="", **kwargs):

--- a/src/saml2/server.py
+++ b/src/saml2/server.py
@@ -83,12 +83,9 @@ class Server(Entity):
         self.init_config(stype)
         self.cache = cache
         self.ticket = {}
-        #
         self.session_db = self.choose_session_storage()
-        # Needed for
         self.symkey = symkey
         self.seed = rndstr()
-        self.iv = os.urandom(16)
         self.lock = threading.Lock()
 
     def getvalid_certificate_str(self):

--- a/tests/test_92_aes.py
+++ b/tests/test_92_aes.py
@@ -1,0 +1,74 @@
+import os
+
+import saml2.aes
+
+
+class TestAES():
+    def test_aes_defaults(self):
+        original_msg = b'ToBeOrNotTobe W.S.'
+        key = os.urandom(16)
+        aes = saml2.aes.AESCipher(key)
+
+        encrypted_msg = aes.encrypt(original_msg)
+        decrypted_msg = aes.decrypt(encrypted_msg)
+        assert decrypted_msg == original_msg
+
+    def test_aes_128_cbc(self):
+        original_msg = b'ToBeOrNotTobe W.S.'
+        key = os.urandom(16)
+        aes = saml2.aes.AESCipher(key)
+        alg = 'aes_128_cbc'
+
+        encrypted_msg = aes.encrypt(original_msg, alg=alg)
+        decrypted_msg = aes.decrypt(encrypted_msg, alg=alg)
+        assert decrypted_msg == original_msg
+
+    def test_aes_128_cfb(self):
+        original_msg = b'ToBeOrNotTobe W.S.'
+        key = os.urandom(16)
+        aes = saml2.aes.AESCipher(key)
+        alg = 'aes_128_cfb'
+
+        encrypted_msg = aes.encrypt(original_msg, alg=alg)
+        decrypted_msg = aes.decrypt(encrypted_msg, alg=alg)
+        assert decrypted_msg == original_msg
+
+    def test_aes_192_cbc(self):
+        original_msg = b'ToBeOrNotTobe W.S.'
+        key = os.urandom(24)
+        aes = saml2.aes.AESCipher(key)
+        alg = 'aes_192_cbc'
+
+        encrypted_msg = aes.encrypt(original_msg, alg=alg)
+        decrypted_msg = aes.decrypt(encrypted_msg, alg=alg)
+        assert decrypted_msg == original_msg
+
+    def test_aes_192_cfb(self):
+        original_msg = b'ToBeOrNotTobe W.S.'
+        key = os.urandom(24)
+        aes = saml2.aes.AESCipher(key)
+        alg = 'aes_192_cfb'
+
+        encrypted_msg = aes.encrypt(original_msg, alg=alg)
+        decrypted_msg = aes.decrypt(encrypted_msg, alg=alg)
+        assert decrypted_msg == original_msg
+
+    def test_aes_256_cbc(self):
+        original_msg = b'ToBeOrNotTobe W.S.'
+        key = os.urandom(32)
+        aes = saml2.aes.AESCipher(key)
+        alg = 'aes_256_cbc'
+
+        encrypted_msg = aes.encrypt(original_msg, alg=alg)
+        decrypted_msg = aes.decrypt(encrypted_msg, alg=alg)
+        assert decrypted_msg == original_msg
+
+    def test_aes_256_cfb(self):
+        original_msg = b'ToBeOrNotTobe W.S.'
+        key = os.urandom(32)
+        aes = saml2.aes.AESCipher(key)
+        alg = 'aes_256_cfb'
+
+        encrypted_msg = aes.encrypt(original_msg, alg=alg)
+        decrypted_msg = aes.decrypt(encrypted_msg, alg=alg)
+        assert decrypted_msg == original_msg


### PR DESCRIPTION
Discussion on #417 

#### Always generate a random IV for AES operations.

Quoting @obi1kenobi:
> Initialization vector reuse like this is a security concern, since it leaks
> information about the encrypted data to attackers, regardless of the
> encryption mode used.
> Instead of relying on a fixed, randomly-generated IV, it would be better to
> randomly-generate a new IV for every encryption operation.

- Drop `AESCipher` `CTR` and `ECB` support
- Fix `AESCipher` IV reuse
- Address `CVE-2017-1000246`

Fixes #417 

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?
