### PR TITLE
Fix warnings and minor cleanup

### DIFF
--- a/src/saml2/__init__.py
+++ b/src/saml2/__init__.py
@@ -586,7 +586,8 @@ class SamlBase(ExtensionContainer):
 
         for elem in elements:
             uri_set = self.get_ns_map_attribute(elem.attrib, uri_set)
-            uri_set = self.get_ns_map(elem.getchildren(), uri_set)
+            children = list(elem)
+            uri_set = self.get_ns_map(children, uri_set)
             uri = self.tag_get_uri(elem)
             if uri is not None:
                 uri_set.add(uri)
@@ -651,7 +652,7 @@ class SamlBase(ExtensionContainer):
 
         # fixup all elements in the tree
         memo = {}
-        for elem in elem.getiterator():
+        for elem in elem.iter():
             self.fixup_element_prefixes(elem, uri_map, memo)
 
     def fixup_element_prefixes(self, elem, uri_map, memo):

--- a/src/saml2/cert.py
+++ b/src/saml2/cert.py
@@ -150,7 +150,6 @@ class OpenSSLWrapper(object):
         cert.set_pubkey(k)
         cert.sign(k, hash_alg)
 
-        filesCreated = False
         try:
             if request:
                 tmp_cert = crypto.dump_certificate_request(crypto.FILETYPE_PEM,
@@ -169,33 +168,18 @@ class OpenSSLWrapper(object):
             else:
                 tmp_key = crypto.dump_privatekey(crypto.FILETYPE_PEM, k)
             if write_to_file:
-                fc = open(c_f, "wt")
-                fk = open(k_f, "wt")
-
-                if request:
+                with open(c_f, 'wt') as fc:
                     fc.write(tmp_cert.decode('utf-8'))
-                else:
-                    fc.write(tmp_cert.decode('utf-8'))
-                fk.write(tmp_key.decode('utf-8'))
-                filesCreated = True
-                try:
-                    fc.close()
-                except:
-                    pass
-
-                try:
-                    fk.close()
-                except:
-                    pass
+                with open(k_f, 'wt') as fk:
+                    fk.write(tmp_key.decode('utf-8'))
                 return c_f, k_f
             return tmp_cert, tmp_key
         except Exception as ex:
             raise CertificateError("Certificate cannot be generated.", ex)
 
     def write_str_to_file(self, file, str_data):
-        f = open(file, "wt")
-        f.write(str_data)
-        f.close()
+        with open(file, 'wt') as f:
+            f.write(str_data)
 
     def read_str_from_file(self, file, type="pem"):
         with open(file, 'rb') as f:

--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -373,7 +373,6 @@ class Config(object):
             config_file = config_file[:-3]
 
         mod = self._load(config_file)
-        # return self.load(eval(open(config_file).read()))
         return self.load(copy.deepcopy(mod.CONFIG), metadata_construction)
 
     def load_metadata(self, metadata_conf):

--- a/src/saml2/eptid.py
+++ b/src/saml2/eptid.py
@@ -56,6 +56,9 @@ class Eptid(object):
             self[key] = val
             return val
 
+    def close(self):
+        pass
+
 
 class EptidShelve(Eptid):
     def __init__(self, secret, filename):
@@ -64,3 +67,6 @@ class EptidShelve(Eptid):
             if filename.endswith('.db'):
                 filename = filename.rsplit('.db', 1)[0]
         self._db = shelve.open(filename, writeback=True, protocol=2)
+
+    def close(self):
+        self._db.close()

--- a/src/saml2/mdbcache.py
+++ b/src/saml2/mdbcache.py
@@ -31,7 +31,7 @@ class Cache(object):
         self.debug = debug
 
     def delete(self, subject_id):
-        self._cache.remove({"subject_id": subject_id})
+        self._cache.delete_many({'subject_id': subject_id})
 
     def get_identity(self, subject_id, entities=None,
                      check_not_on_or_after=True):
@@ -196,4 +196,4 @@ class Cache(object):
                            {"$set": {"timestamp": newtime}})
 
     def clear(self):
-        self._cache.remove()
+        self._cache.delete_many({})

--- a/src/saml2/mongo_store.py
+++ b/src/saml2/mongo_store.py
@@ -178,11 +178,7 @@ class IdentMDB(IdentDB):
         # else create and return a new one
         return self.construct_nameid(_id, name_id_policy=name_id_policy)
 
-    def close(self):
-        pass
 
-
-#------------------------------------------------------------------------------
 class MDB(object):
     primary_key = "mdb"
 

--- a/src/saml2/s2repoze/plugins/formswithhidden.py
+++ b/src/saml2/s2repoze/plugins/formswithhidden.py
@@ -116,7 +116,8 @@ def make_plugin(login_form_qs='__do_login', rememberer_name=None, form=None):
         raise ValueError(
             'must include rememberer key (name of another IIdentifier plugin)')
     if form is not None:
-        form = open(form).read()
+        with open(form, 'r') as f:
+            form = f.read()
     plugin = FormHiddenPlugin(login_form_qs, rememberer_name, form)
     return plugin
 

--- a/src/saml2/server.py
+++ b/src/saml2/server.py
@@ -113,7 +113,6 @@ class Server(Entity):
             typ, data = _spec
             if typ.lower() == "mongodb":
                 from saml2.mongo_store import SessionStorageMDB
-
                 return SessionStorageMDB(database=data, collection="session")
 
         raise NotImplementedError("No such storage type implemented")
@@ -142,15 +141,12 @@ class Server(Entity):
                 idb = _shelve_compat(addr, writeback=True, protocol=2)
             elif typ == "memcached":
                 import memcache
-
                 idb = memcache.Client(addr)
             elif typ == "dict":  # in-memory dictionary
                 idb = {}
             elif typ == "mongodb":
                 from saml2.mongo_store import IdentMDB
-
                 self.ident = IdentMDB(database=addr, collection="ident")
-
             elif typ == "identdb":
                 mod, clas = addr.rsplit('.', 1)
                 mod = importlib.import_module(mod)
@@ -182,7 +178,6 @@ class Server(Entity):
                     self.eptid = EptidShelve(secret, addr)
                 elif typ == "mongodb":
                     from saml2.mongo_store import EptidMDB
-
                     self.eptid = EptidMDB(secret, database=addr,
                                           collection="eptid")
                 else:

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -488,54 +488,6 @@ def base64_to_long(data):
     return intarr2long(dehexlify(_d))
 
 
-def key_from_key_value(key_info):
-    res = []
-    for value in key_info.key_value:
-        if value.rsa_key_value:
-            e = base64_to_long(value.rsa_key_value.exponent)
-            m = base64_to_long(value.rsa_key_value.modulus)
-            key = RSA.construct((m, e))
-            res.append(key)
-    return res
-
-
-def key_from_key_value_dict(key_info):
-    res = []
-    if not "key_value" in key_info:
-        return res
-
-    for value in key_info["key_value"]:
-        if "rsa_key_value" in value:
-            e = base64_to_long(value["rsa_key_value"]["exponent"])
-            m = base64_to_long(value["rsa_key_value"]["modulus"])
-            key = RSA.construct((m, e))
-            res.append(key)
-    return res
-
-
-# =============================================================================
-
-
-# def rsa_load(filename):
-#    """Read a PEM-encoded RSA key pair from a file."""
-#    return M2Crypto.RSA.load_key(filename, M2Crypto.util
-# .no_passphrase_callback)
-#
-#
-# def rsa_loads(key):
-#    """Read a PEM-encoded RSA key pair from a string."""
-#    return M2Crypto.RSA.load_key_string(key,
-#                                        M2Crypto.util.no_passphrase_callback)
-
-
-def rsa_eq(key1, key2):
-    # Check if two RSA keys are in fact the same
-    if key1.n == key2.n and key1.e == key2.e:
-        return True
-    else:
-        return False
-
-
 def extract_rsa_key_from_x509_cert(pem):
     cert = load_pem_x509_certificate(pem, backend)
     return cert.public_key()

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -53,6 +53,8 @@ AUTHN = {
     "authn_auth": "http://www.example.com/login"
 }
 
+encode_fn = getattr(base64, 'encodebytes', base64.encodestring)
+
 
 def generate_cert():
     sn = uuid.uuid4().urn
@@ -177,7 +179,7 @@ class TestClient:
             "E8042FB4-4D5B-48C3-8E14-8EDD852790DD",
             format=saml.NAMEID_FORMAT_PERSISTENT,
             message_id="id1")
-        reqstr = "%s" % req.to_string().decode('utf-8')
+        reqstr = "%s" % req.to_string().decode()
 
         assert req.destination == "https://idp.example.com/idp/"
         assert req.id == "id1"
@@ -411,7 +413,7 @@ class TestClient:
 
         resp_str = "%s" % resp
 
-        resp_str = base64.encodestring(resp_str.encode('utf-8'))
+        resp_str = encode_fn(resp_str.encode())
 
         authn_response = self.client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,
@@ -455,7 +457,7 @@ class TestClient:
             userid="also0001@example.com",
             authn=AUTHN)
 
-        resp_str = base64.encodestring(resp_str.encode('utf-8'))
+        resp_str = encode_fn(resp_str.encode())
 
         self.client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,
@@ -505,7 +507,7 @@ class TestClient:
 
         resp_str = "%s" % resp
 
-        resp_str = base64.encodestring(resp_str.encode('utf-8'))
+        resp_str = encode_fn(resp_str.encode())
 
         authn_response = _client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,
@@ -540,7 +542,7 @@ class TestClient:
 
         resp_str = "%s" % resp
 
-        resp_str = base64.encodestring(resp_str.encode('utf-8'))
+        resp_str = encode_fn(resp_str.encode())
 
         authn_response = _client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,
@@ -575,7 +577,7 @@ class TestClient:
 
         resp_str = "%s" % resp
 
-        resp_str = base64.encodestring(resp_str.encode('utf-8'))
+        resp_str = encode_fn(resp_str.encode())
 
         authn_response = _client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,
@@ -619,7 +621,7 @@ class TestClient:
 
         resp_str = "%s" % resp
 
-        resp_str = base64.encodestring(resp_str.encode('utf-8'))
+        resp_str = encode_fn(resp_str.encode())
 
         authn_response = _client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,
@@ -672,7 +674,7 @@ class TestClient:
 
         resp_str = "%s" % resp
 
-        resp_str = base64.encodestring(resp_str.encode('utf-8'))
+        resp_str = encode_fn(resp_str.encode())
 
         authn_response = _client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,
@@ -708,7 +710,7 @@ class TestClient:
 
         resp_str = "%s" % resp
 
-        resp_str = base64.encodestring(resp_str.encode('utf-8'))
+        resp_str = encode_fn(resp_str.encode())
 
         authn_response = _client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,
@@ -751,7 +753,7 @@ class TestClient:
 
         resp_str = "%s" % resp
 
-        resp_str = base64.encodestring(resp_str.encode('utf-8'))
+        resp_str = encode_fn(resp_str.encode())
 
         authn_response = _client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,
@@ -927,7 +929,7 @@ class TestClient:
 
         # seresp = samlp.response_from_string(enctext)
 
-        resp_str = base64.encodestring(enctext.encode('utf-8'))
+        resp_str = encode_fn(enctext.encode())
         # Now over to the client side
         # Explicitely allow unsigned responses for this and the following 2 tests
         self.client.want_response_signed = False
@@ -1030,7 +1032,7 @@ class TestClient:
 
         # seresp = samlp.response_from_string(enctext)
 
-        resp_str = base64.encodestring(enctext.encode('utf-8'))
+        resp_str = encode_fn(enctext.encode())
         # Now over to the client side
         resp = self.client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,
@@ -1315,7 +1317,7 @@ class TestClient:
 
         # seresp = samlp.response_from_string(enctext)
 
-        resp_str = base64.encodestring(str(response).encode('utf-8'))
+        resp_str = encode_fn(str(response).encode())
         # Now over to the client side
         resp = self.client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,


### PR DESCRIPTION
I noticed several warnings while testing and trying the code. This is a cleanup for all but one remaining warning which is part of `defusedxml`:

```
pysaml2/venv/lib/python3.7/site-packages/defusedxml/ElementTree.py:68:
DeprecationWarning: The html argument of XMLParser() is deprecated
  _XMLParser.__init__(self, html, target, encoding)
```

The changeset also removes some code that refers to `RSA` type of `Cryptodome.PublicKey` which is no longer used.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?
