### PR TITLE
Specify minimal version for cryptography package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ scripts =
     tools/merge_metadata.py
     tools/parse_xsd2.py
 install_requires =
-    cryptography
+    cryptography >= 1.4
     defusedxml
     future
     pyOpenSSL


### PR DESCRIPTION
Otherwise if pysaml is installed with an older release of cryptography package it would fail with
AttributeError: '_RSAPrivateKey' object has no attribute 'sign'

### All Submissions:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



