### PR TITLE
Multiple AttributeStatement tags per Assertion

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -649,7 +649,7 @@ class AuthnResponse(StatusResponse):
                         self.allow_unknown_attributes)
 
     def get_identity(self):
-        """ The assertion can contain zero or one attributeStatements
+        """ The assertion can contain zero or more attributeStatements
 
         """
         ava = {}
@@ -662,9 +662,11 @@ class AuthnResponse(StatusResponse):
                             ava.update(self.read_attribute_statement(
                                 tmp_assertion.attribute_statement[0]))
             if _assertion.attribute_statement:
-                assert len(_assertion.attribute_statement) == 1
-                _attr_statem = _assertion.attribute_statement[0]
-                ava.update(self.read_attribute_statement(_attr_statem))
+                logger.debug("Assertion contains %s attribute statement(s)",
+                             (len(self.assertion.attribute_statement)))
+                for _attr_statem in _assertion.attribute_statement:
+                    logger.debug("Attribute Statement: %s" % (_attr_statem,))
+                    ava.update(self.read_attribute_statement(_attr_statem))
             if not ava:
                 logger.debug("Assertion contains no attribute statements")
         return ava


### PR DESCRIPTION
This was necessary to implement a real-world SSO integration,
which required handling multiple AttributeStatement elements
within a single assertion in a SAML response.

Orginally this change was implemented in a private fork
by Thomas Knott for pysaml 2.2.0, and has been ported
by Sheila Allen for use in pysaml 4.6.0 to hopefully
merge upstream.

There was a similar [PR in 2015 for the same need by pcrownov](https://github.com/IdentityPython/pysaml2/pull/205/files),
which was never merged due to unrelated changes.

I have not yet written a test for this special case, but it does not
break any existing tests. Due to the complexity of the existing
test for this method (test_sign_then_encrypt_assertion_advice_2,
nearly 300 lines), the time/effort looks daunting. Would an additional
test be required for merge?

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



