### PR TITLE
Docstrings improvements for NameID and argtree.add_path

### DIFF
--- a/src/saml2/argtree.py
+++ b/src/saml2/argtree.py
@@ -53,10 +53,34 @@ def set_arg(cls, arg, value):
 
 def add_path(tdict, path):
     """
+    Create or extend an argument tree `tdict` from `path`.
 
     :param tdict: a dictionary representing a argument tree
     :param path: a path list
     :return: a dictionary
+
+    Convert a list of items in a 'path' into a nested dict, where the
+    second to last item becomes the key for the final item. The remaining
+    items in the path become keys in the nested dict around that final pair
+    of items.
+
+    For example, for input values of:
+        tdict={}
+        path = ['assertion', 'subject', 'subject_confirmation',
+                'method', 'urn:oasis:names:tc:SAML:2.0:cm:bearer']
+
+        Returns an output value of:
+           {'assertion': {'subject': {'subject_confirmation':
+                         {'method': 'urn:oasis:names:tc:SAML:2.0:cm:bearer'}}}}
+
+    Another example, this time with a non-empty tdict input:
+
+        tdict={'method': 'urn:oasis:names:tc:SAML:2.0:cm:bearer'},
+        path=['subject_confirmation_data', 'in_response_to', '_012345']
+
+        Returns an output value of:
+            {'subject_confirmation_data': {'in_response_to': '_012345'},
+             'method': 'urn:oasis:names:tc:SAML:2.0:cm:bearer'}
     """
     t = tdict
     for step in path[:-2]:

--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -811,7 +811,16 @@ def base_id_from_string(xml_string):
 
 
 class NameID(NameIDType_):
-    """The urn:oasis:names:tc:SAML:2.0:assertion:NameID element """
+    """The urn:oasis:names:tc:SAML:2.0:assertion:NameID element
+
+    From the Oasis SAML2 Technical Overview:
+
+    "The <NameID> element within a <Subject> offers the ability to provide name
+     identifiers in a number of different formats. SAML's predefined formats
+     include: Email address, X.509 subject name, Windows domain qualified name,
+     Kerberos principal name, Entity identifier, Persistent identifier,
+     Transient identifier."
+     """
 
     c_tag = 'NameID'
     c_namespace = NAMESPACE


### PR DESCRIPTION
Making docstrings more explanatory for NameID and argtree.add_path

I ran across these while stepping through tests, and writing docstrings
helps me understand them. Please let me know if you agree/disagree
with the added content. Thanks!

Sphinx docs build output said:

    pysaml2/src/saml2/argtree.py:docstring of saml2.argtree.add_path:15: WARNING: Unexpected indentation.

I don't know if that matters, since I did not see any content generated out of docstrings using Sphinx autoclass or autofunction directives.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



