### PR TITLE
Raise ValueError for invalid attribute type

### DIFF
--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -224,7 +224,7 @@ class AttributeValueBase(SamlBase):
                         elif typ == "xs:base64Binary":
                             pass
                         else:
-                            ValueError("Type and value doesn't match")
+                            raise ValueError("Type and value doesn't match")
             elif isinstance(val, bool):
                 if val:
                     val = "true"

--- a/tests/test_02_saml.py
+++ b/tests/test_02_saml.py
@@ -243,6 +243,10 @@ class TestSAMLBase:
         av.set_text(None)
         assert av.text == ""
 
+        av = AttributeValue()
+        av.set_type('invalid')
+        raises(ValueError, "av.set_text('free text')")
+
     def test_make_vals_div(self):
         foo = saml2.make_vals(666, AttributeValue, part=True)
         assert foo.text == "666"


### PR DESCRIPTION
Without this patch, the AttributeValueBase set_text method checks for a
valid xsi:type before setting the text value, but when it gets to the
catchall case, instead of raising an exception it simply creates an
unassigned ValueError instance and does nothing with it. This is clearly
not intentional, and it is a problem because it means it is possible to
set an invalid xsi:type for an AttributeValue. This patch corrects the
error by raising the ValueError exception rather than letting it
disappear into the ether.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



