### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=40.0.0", "wheel"]


### PR DESCRIPTION
The version=file:VERSION line in setup.cfg actually requires `setuptools>=40.0.0`, so this adds a pyproject.toml file describing the minimum build dependencies of the project.

You can verify that this fixes an issue by using `pip install` or `pip wheel` on master when your `setuptools` version is `39.0.1` or `40.0.0`. In the previous case, the version is set to `file-VERSION`.

This is the [PEP 518](https://www.python.org/dev/peps/pep-0518/)-compliant way to pin `setuptools`.

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
*  Have you written new tests for your changes? **N/A**
* Does your submission pass tests? **N/A**
* This project follows PEP8 style guide. Have you run your code against the 'flake8' linter? **N/A**



