### PR TITLE
stop xs:anyType from raising a ValueError

### DIFF
--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -205,9 +205,11 @@ class AttributeValueBase(SamlBase):
             val = _b64_encode_fn(val)
             self.set_type("xs:base64Binary")
         else:
-            if isinstance(val, six.binary_type):
+            if typ == "xs:anyType":
+                pass
+            elif isinstance(val, six.binary_type):
                 val = val.decode()
-            if isinstance(val, six.string_types):
+            elif isinstance(val, six.string_types):
                 if not typ:
                     self.set_type("xs:string")
                 else:
@@ -253,10 +255,7 @@ class AttributeValueBase(SamlBase):
                     self._extatt[XSI_TYPE] = typ
                 val = ""
             else:
-                if typ == "xs:anyType":
-                    pass
-                else:
-                    raise ValueError
+                raise ValueError
 
         SamlBase.__setattr__(self, "text", val)
         return self


### PR DESCRIPTION
GH-539 started raising ValueError for xs:anyType
This PR attempts to fix this by checking for xs:anyType first

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?
