### PR TITLE
Refactor AttributeValueBase set_text method

### DIFF
--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -91,43 +91,6 @@ _b64_decode_fn = getattr(base64, 'decodebytes', base64.decodestring)
 _b64_encode_fn = getattr(base64, 'encodebytes', base64.encodestring)
 
 
-def _decode_attribute_value(typ, text):
-    if typ == XSD + "string":
-        return text or ""
-    if typ == XSD + "integer" or typ == XSD + "int":
-        return str(int(text))
-    if typ == XSD + "float" or typ == XSD + "double":
-        return str(float(text))
-    if typ == XSD + "boolean":
-        return str(text.lower() == "true")
-    if typ == XSD + "base64Binary":
-        return _b64_decode_fn(text)
-    raise ValueError("type %s not supported" % type)
-
-
-def _verify_value_type(typ, val):
-    #  print("verify value type: %s, %s" % (typ, val))
-    if typ == XSD + "string":
-        try:
-            return str(val)
-        except UnicodeEncodeError:
-            if six.PY2:
-                return unicode(val)
-            else:
-                return val.decode('utf8')
-    if typ == XSD + "integer" or typ == XSD + "int":
-        return int(val)
-    if typ == XSD + "float" or typ == XSD + "double":
-        return float(val)
-    if typ == XSD + "boolean":
-        if val.lower() == "true" or val.lower() == "false":
-            pass
-        else:
-            raise ValueError("Faulty boolean value")
-    if typ == XSD + "base64Binary":
-        return _b64_decode_fn(val.encode())
-
-
 class AttributeValueBase(SamlBase):
     def __init__(self,
                  text=None,
@@ -325,11 +288,6 @@ class AttributeValueBase(SamlBase):
             self.set_text(tree.text)
             if XSI_NIL in self.extension_attributes:
                 del self.extension_attributes[XSI_NIL]
-            try:
-                typ = self.extension_attributes[XSI_TYPE]
-                _verify_value_type(typ, getattr(self, "text"))
-            except KeyError:
-                pass
 
 
 class BaseIDAbstractType_(SamlBase):

--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -218,67 +218,71 @@ class AttributeValueBase(SamlBase):
             type(None): '',
         }
 
+        # entries of xs-types each declaring:
+        # - a corresponding python type
+        # - a function to turn a string into that type
+        # - a function to turn that type into a text-value
         xs_types_map = {
             'xs:string': {
                 'type': _str,
-                'typed_constructor': _str,
-                'text_constructor': _str,
+                'to_type': _str,
+                'to_text': _str,
             },
             'xs:integer': {
                 'type': int,
-                'typed_constructor': int,
-                'text_constructor': _str,
+                'to_type': int,
+                'to_text': _str,
             },
             'xs:short': {
                 'type': int,
-                'typed_constructor': int,
-                'text_constructor': _str,
+                'to_type': int,
+                'to_text': _str,
             },
             'xs:int': {
                 'type': int,
-                'typed_constructor': int,
-                'text_constructor': _str,
+                'to_type': int,
+                'to_text': _str,
             },
             'xs:long': {
                 'type': int,
-                'typed_constructor': int,
-                'text_constructor': _str,
+                'to_type': int,
+                'to_text': _str,
             },
             'xs:float': {
                 'type': float,
-                'typed_constructor': float,
-                'text_constructor': _str,
+                'to_type': float,
+                'to_text': _str,
             },
             'xs:double': {
                 'type': float,
-                'typed_constructor': float,
-                'text_constructor': _str,
+                'to_type': float,
+                'to_text': _str,
             },
             'xs:boolean': {
                 'type': bool,
-                'typed_constructor': lambda x: {
+                'to_type': lambda x: {
                     'true': True,
                     'false': False,
                 }[_str(x).lower()],
-                'text_constructor': lambda x: _str(x).lower(),
+                'to_text': lambda x: _str(x).lower(),
             },
             'xs:base64Binary': {
                 'type': _str,
-                'typed_constructor': _str,
-                'text_constructor': lambda x:
+                'to_type': _str,
+                'to_text': lambda x:
                     _b64_encode_fn(x.encode())
                     if base64encode
                     else x,
             },
             'xs:anyType': {
                 'type': type(value),
-                'typed_constructor': lambda x: x,
-                'text_constructor': lambda x: x,
+                'to_type': lambda x: x,
+                'to_text': lambda x: x,
             },
             '': {
                 'type': type(None),
-                'typed_constructor': lambda x: None,
-                'text_constructor': lambda x: '',
+                'to_type': lambda x: None,
+                'to_text': lambda x: '',
             },
         }
 
@@ -289,13 +293,13 @@ class AttributeValueBase(SamlBase):
             or xs_type_from_type.get(type(value), type(None))
         xs_type_map = xs_types_map.get(xs_type, {})
         valid_type = xs_type_map.get('type', type(None))
-        to_typed = xs_type_map.get('typed_constructor', str)
-        to_text = xs_type_map.get('text_constructor', str)
+        to_type = xs_type_map.get('to_type', str)
+        to_text = xs_type_map.get('to_text', str)
 
         # cast to correct type before type-checking
         if type(value) is _str and valid_type is not _str:
             try:
-                value = to_typed(value)
+                value = to_type(value)
             except (TypeError, ValueError, KeyError) as e:
                 # the cast failed
                 _wrong_type_value(xs_type=xs_type, value=value)

--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -209,7 +209,6 @@ class AttributeValueBase(SamlBase):
         }
 
         _type_from_xs_type = {
-            'xs:anyType':      str,
             'xs:string':       str,
             'xs:integer':      int,
             'xs:short':        int,
@@ -219,11 +218,11 @@ class AttributeValueBase(SamlBase):
             'xs:double':       float,
             'xs:boolean':      bool,
             'xs:base64Binary': str,
+            'xs:anyType':      type(value),
             '':                type(None),
         }
 
         _typed_value_constructor_from_xs_type = {
-            'xs:anyType':      str,
             'xs:string':       str,
             'xs:integer':      int,
             'xs:short':        int,
@@ -236,11 +235,11 @@ class AttributeValueBase(SamlBase):
                 else False if str(x).lower() == 'false'
                 else None,
             'xs:base64Binary': str,
+            'xs:anyType':      lambda x: value,
             '':                lambda x: None,
         }
 
         _text_constructor_from_xs_type = {
-            'xs:anyType':      str,
             'xs:string':       str,
             'xs:integer':      str,
             'xs:short':        str,
@@ -253,6 +252,7 @@ class AttributeValueBase(SamlBase):
                 _b64_encode_fn(x.encode())
                 if base64encode
                 else x,
+            'xs:anyType':      lambda x: value,
             '':                lambda x: '',
         }
 
@@ -263,12 +263,7 @@ class AttributeValueBase(SamlBase):
             'xs:base64Binary'    \
             if base64encode      \
             else self.get_type() \
-            or _xs_type_from_type.get(type(value))
-
-        if xs_type is None:
-            msg_tpl = 'No corresponding xs-type for {type}:{value}'
-            msg = msg_tpl.format(type=type(value), value=value)
-            raise ValueError(msg)
+            or _xs_type_from_type.get(type(value), type(None))
 
         valid_type = _type_from_xs_type.get(xs_type, type(None))
         to_typed = _typed_value_constructor_from_xs_type.get(xs_type, str)

--- a/tests/test_02_saml.py
+++ b/tests/test_02_saml.py
@@ -230,22 +230,55 @@ class TestSAMLBase:
         assert "saml:AttributeValue" in nsstr
         assert "saml:AttributeValue" not in txt
 
-    def test_set_text(self):
-        av = AttributeValue()
-        av.set_text(True)
-        assert av.text == "true"
-        av.set_text(False)
-        assert av.text == "false"
-        # can't change value to another type
-        raises(AssertionError, "av.set_text(491)")
-
+    def test_set_text_empty(self):
         av = AttributeValue()
         av.set_text(None)
-        assert av.text == ""
+        assert av.get_type() == ''
+        assert av.text == ''
 
+    def test_set_text_value(self):
+        value = 123
+        av = AttributeValue(value)
+        assert av.get_type() == 'xs:integer'
+        assert av.text == str(value)
+
+    def test_set_text_update_same_type(self):
         av = AttributeValue()
-        av.set_type('invalid')
-        raises(ValueError, "av.set_text('free text')")
+        av.set_text(True)
+        assert av.get_type() == 'xs:boolean'
+        assert av.text == 'true'
+        av.set_text(False)
+        assert av.get_type() == 'xs:boolean'
+        assert av.text == 'false'
+
+    def test_set_text_cannot_change_value_type(self):
+        av = AttributeValue()
+        av.set_text(True)
+        assert av.get_type() == 'xs:boolean'
+        assert av.text == 'true'
+        with raises(ValueError):
+            av.set_text(123)
+        assert av.get_type() == 'xs:boolean'
+        assert av.text == 'true'
+
+    def test_set_xs_type_anytype_unchanged_value(self):
+        av = AttributeValue()
+        av.set_type('xs:anyType')
+        for value in [
+            [1, 2, 3],
+            {'key': 'value'},
+            True,
+            123,
+        ]:
+            av.set_text(value)
+            # the value is unchanged
+            assert av.text == value
+
+    def test_set_invalid_type_before_text(self):
+        av = AttributeValue()
+        av.set_type('invalid-type')
+        with raises(ValueError):
+            av.set_text('foobar')
 
     def test_make_vals_div(self):
         foo = saml2.make_vals(666, AttributeValue, part=True)

--- a/tests/test_02_saml.py
+++ b/tests/test_02_saml.py
@@ -43,13 +43,15 @@ class TestExtensionElement:
         print(ava)
         ee = saml2.ExtensionElement("")
 
-        raises(KeyError, "ee.loadd(ava)")
+        with raises(KeyError):
+            ee.loadd(ava)
 
         ava["tag"] = "foo"
         del ava["namespace"]
 
         ee = saml2.ExtensionElement("")
-        raises(KeyError, "ee.loadd(ava)")
+        with raises(KeyError):
+            ee.loadd(ava)
 
     def test_find_children(self):
         ava = {
@@ -211,8 +213,8 @@ class TestSAMLBase:
     def test_make_vals_multi_dict(self):
         ava = ["foo", "bar", "lions", "saints"]
 
-        raises(Exception,
-               "saml2.make_vals(ava, AttributeValue, Attribute(), part=True)")
+        with raises(Exception):
+            saml2.make_vals(ava, AttributeValue, Attribute(), part=True)
 
         attr = Attribute()
         saml2.make_vals(ava, AttributeValue, attr, prop="attribute_value")
@@ -654,7 +656,7 @@ BASIC_BASE64_AV = """<?xml version="1.0" encoding="utf-8"?>
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
 Name="FirstName">
-<AttributeValue 
+<AttributeValue
 xsi:type="xs:base64Binary">VU5JTkVUVA==</AttributeValue>
 </Attribute>"""
 


### PR DESCRIPTION
This changeset is a refactor of the `AttributeValueBase.set_text()` method.
The rewrite is done in a _declarative_ fashion. The mappings define the behaviour of the code, while the flow is _common_ for all types.
The changeset also adds new tests that describe the behaviour of the function and make sure that the rewrite behaves the same way.

Related to #539 #543 #544 #546 

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?