### PR TITLE
Never map FriendlyName to SAML name

### DIFF
--- a/src/saml2/attribute_converter.py
+++ b/src/saml2/attribute_converter.py
@@ -118,42 +118,7 @@ def to_local(acs, statement, allow_unknown_attributes=False):
     :param allow_unknown_attributes: If unknown attributes are allowed
     :return: A key,values dictionary
     """
-    if not acs:
-        acs = [AttributeConverter()]
-        acsd = {"": acs}
-    else:
-        acsd = dict([(a.name_format, a) for a in acs])
-
-    ava = {}
-    for attr in statement.attribute:
-        try:
-            _func = acsd[attr.name_format].ava_from
-        except KeyError:
-            if attr.name_format == NAME_FORMAT_UNSPECIFIED or \
-                    allow_unknown_attributes:
-                _func = acs[0].lcd_ava_from
-            else:
-                logger.info("Unsupported attribute name format: %s",
-                    attr.name_format)
-                continue
-
-        try:
-            key, val = _func(attr)
-        except KeyError:
-            if allow_unknown_attributes:
-                key, val = acs[0].lcd_ava_from(attr)
-            else:
-                logger.info("Unknown attribute name: %s", attr)
-                continue
-        except AttributeError:
-            continue
-
-        try:
-            ava[key].extend(val)
-        except KeyError:
-            ava[key] = val
-
-    return ava
+    return list_to_local(acs, statement.attribute, allow_unknown_attributes)
 
 
 def list_to_local(acs, attrlist, allow_unknown_attributes=False):

--- a/src/saml2/attribute_converter.py
+++ b/src/saml2/attribute_converter.py
@@ -278,23 +278,15 @@ class AttributeConverter(object):
 
     def lcd_ava_from(self, attribute):
         """
-        In nothing else works, this should
+        If nothing else works, this should
 
-        :param attribute: An Attribute Instance
+        :param attribute: an Attribute instance
         :return:
         """
-        try:
-            name = attribute.friendly_name.strip()
-        except AttributeError:
-            name = attribute.name.strip()
-
-        values = []
-        for value in attribute.attribute_value:
-            if not value.text:
-                values.append('')
-            else:
-                values.append(value.text.strip())
-
+        name = attribute.name.strip()
+        values = [
+            (value.text or '').strip()
+            for value in attribute.attribute_value]
         return name, values
 
     def fail_safe_fro(self, statement):

--- a/tests/test_19_attribute_converter.py
+++ b/tests/test_19_attribute_converter.py
@@ -192,7 +192,7 @@ class TestAC():
         ava = to_local(self.acs, ats, True)
         assert ava == {'eduPersonAffiliation': ['staff'],
                        'givenName': ['Roland'], 'sn': ['Hedberg'],
-                       'swissEduPersonHomeOrganizationType': ['others'],
+                       'urn:oid:2.16.756.1.2.5.1.1.5': ['others'],
                        'uid': ['demouser'], 'urn:example:com:foo': ['Thing'],
                        'user_id': ['bob']}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new/updated existing tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?

# Explanation
This PR fixes (removes) erroneous conversion of incoming SAML2 attributes to FriendlyName versions. From the SAML2 Core document:
## FriendlyName [Optional]
A string that provides a more human-readable form of the attribute's name, which may be useful in
cases in which the actual Name is complex or opaque, such as an OID or a UUID. This attribute's
value MUST NOT be used as a basis for formally identifying SAML attributes.

# Justification
We want to handle original SAML attribute names in Satosa internal_attributes.yaml mapping file, therefor we bypass pysaml's attribute conversion to shortnames by supplying empty to/from dictionaries in backend configuration (this is a hack worthy of a PR in itself, but we don't complain).

Recently however we discovered that, in the absence of a valid conversion mapping, pysaml relies on FriendlyName as a last resort to create anything but the original SAML attribute name for further processing. This is unwanted behaviour and not allowed by the specs.
