### PR TITLE
Handle non ascii in response class __str__

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -319,7 +319,10 @@ class StatusResponse(object):
     def _loads(self, xmldata, decode=True, origxml=None):
 
         # own copy
-        self.xmlstr = xmldata[:]
+        if isinstance(xmldata, six.binary_type):
+            self.xmlstr = xmldata[:].decode('utf-8')
+        else:
+            self.xmlstr = xmldata[:]
         logger.debug("xmlstr: %s", self.xmlstr)
         if origxml:
             self.origxml = origxml
@@ -1082,16 +1085,13 @@ class AuthnResponse(StatusResponse):
                     "session_index": authn_statement.session_index}
 
     def __str__(self):
-        if six.PY2:
-            return self.xmlstr.decode('utf-8')
-        else:
-            return str(self.xmlstr)
+        return self.xmlstr
 
     def verify_recipient(self, recipient):
         """
         Verify that I'm the recipient of the assertion
-        
-        :param recipient: A URI specifying the entity or location to which an 
+
+        :param recipient: A URI specifying the entity or location to which an
             attesting entity can present the assertion.
         :return: True/False
         """

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -1082,9 +1082,10 @@ class AuthnResponse(StatusResponse):
                     "session_index": authn_statement.session_index}
 
     def __str__(self):
-        if isinstance(self.xmlstr, six.string_types):
-            return self.xmlstr
-        return str(self.xmlstr)
+        if six.PY2:
+            return self.xmlstr.decode('utf-8')
+        else:
+            return str(self.xmlstr)
 
     def verify_recipient(self, recipient):
         """

--- a/tests/test_65_authn_query.py
+++ b/tests/test_65_authn_query.py
@@ -65,11 +65,6 @@ def test_flow():
 
     with closing(Server(config_file="idp_all_conf")) as idp:
         relay_state = "FOO"
-        # -- dummy request ---
-        orig_req = AuthnRequest(
-            issuer=sp._issuer(),
-            name_id_policy=NameIDPolicy(allow_create="true",
-                                        format=NAMEID_FORMAT_TRANSIENT))
 
         # == Create an AuthnRequest response
 


### PR DESCRIPTION
I was apparently confused in my last PR (#550) when I tried to fix the response class `__str__`.

This should (hopefully) be the correct way of handling a response string containing non ascii characters.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



