### PR TITLE
Fix AuthnResponse.condition_ok to be not so restrictive

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -569,11 +569,14 @@ class AuthnResponse(StatusResponse):
         # check authn_statement.session_index
 
     def condition_ok(self, lax=False):
+        if not self.assertion.conditions:
+            # Conditions is Optional for Assertion, so, if it's absent, then we
+            # assume that its valid
+            return True
+
         if self.test:
             lax = True
 
-        # The Identity Provider MUST include a <saml:Conditions> element
-        assert self.assertion.conditions
         conditions = self.assertion.conditions
 
         logger.debug("conditions: %s", conditions)


### PR DESCRIPTION
As we can see in specs, Conditions are not required, so we should not to
check assertion on its existence.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



