### PR TITLE
Adds metadata attribute for entity_category_support

### DIFF
--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -54,6 +54,7 @@ COMMON_ARGS = [
     "session_storage",
     "assurance_certification",
     "entity_category",
+    "entity_category_support",
     "xmlsec_path",
     "extension_schemas",
     "cert_handler_extra_class",
@@ -224,6 +225,7 @@ class Config(object):
         self.name_qualifier = ""
         self.assurance_certification = []
         self.entity_category = []
+        self.entity_category_support = []
         self.crypto_backend = 'xmlsec1'
         self.id_attr_name = None
         self.scope = ""

--- a/src/saml2/metadata.py
+++ b/src/saml2/metadata.py
@@ -724,6 +724,15 @@ def entity_descriptor(confd):
         )
         _add_attr_to_entity_attributes(entd.extensions, attr)
 
+    if confd.entity_category_support:
+        if not entd.extensions:
+            entd.extensions = md.Extensions()
+        ava = [AttributeValue(text=c) for c in confd.entity_category_support]
+        attr = Attribute(
+            attribute_value=ava, name="http://macedir.org/entity-category-support"
+        )
+        _add_attr_to_entity_attributes(entd.extensions, attr)
+
     for item in algorithm_support_in_metadata(confd.xmlsec_binary):
         if not entd.extensions:
             entd.extensions = md.Extensions()


### PR DESCRIPTION
This pull request adds support for the metadata attribute http://macedir.org/entity-category-support. This is required (at least) for the IdPs expressing support for entity categories like the [research and scholarship][1] and [code of conduct][2]

[1]: https://refeds.org/category/research-and-scholarship
[2]: https://wiki.refeds.org/display/CODE/SAML+2+Profile+for+the+Data+Protection+Code+of+Conduct?preview=/1605752/1802303/GEANT_DP_CoC_saml2_profile_ver1.1.pdf

### Submission checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



