### PR TITLE
Add a test that client raises the proper exception when parsing an error status response.

### DIFF
--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -1207,8 +1207,6 @@ class Entity(HTTPBase):
             else:
                 response.require_signature = require_signature
                 response = response.verify(keys)
-        except Exception as err:
-            logger.error("Exception verifying assertion: %s" % err)
         else:
             assertions_are_signed = True
         finally:


### PR DESCRIPTION
This test passes in v4.6.3 but is failing in v4.6.4 due to IdentityPython/pysaml2#571

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



