### PR TITLE
Suppress a warning due to python-future

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -9,11 +9,14 @@ import logging
 import os
 import ssl
 import six
+import warnings
 
 from time import mktime
 from binascii import hexlify
 
-from future.backports.urllib.parse import urlencode
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from future.backports.urllib.parse import urlencode
 
 import saml2.cryptography.asymmetric
 import saml2.cryptography.pki


### PR DESCRIPTION
The python-future library is causing a warning about the
imp module being deprecated. See
https://github.com/PythonCharmers/python-future/issues/246
This commit suppresses the warning.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?

No new tests would be useful for this change.

* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



