### PR TITLE
Added ignore for otherwise unignorable ImportWarning

### DIFF
--- a/src/saml2/cryptography/symmetric.py
+++ b/src/saml2/cryptography/symmetric.py
@@ -6,15 +6,10 @@ library. Reference: https://cryptography.io/en/latest/fernet/
 
 import base64 as _base64
 import os as _os
-import warnings as _warnings
 
 import cryptography.fernet as _fernet
 import cryptography.hazmat.backends as _backends
 import cryptography.hazmat.primitives.ciphers as _ciphers
-
-
-_warnings.simplefilter('default')
-_warnings.simplefilter('ignore', ImportWarning)
 
 
 class Default(object):

--- a/src/saml2/cryptography/symmetric.py
+++ b/src/saml2/cryptography/symmetric.py
@@ -14,6 +14,7 @@ import cryptography.hazmat.primitives.ciphers as _ciphers
 
 
 _warnings.simplefilter('default')
+_warnings.simplefilter('ignore', ImportWarning)
 
 
 class Default(object):


### PR DESCRIPTION
This is my first pull request, so I apologize in advance for stupid mistakes.

When used in djangosaml2idp, any imports of saml2.cryptography.symmetric resulted in the following error:

`/usr/local/lib/python3.7/importlib/_bootstrap.py:219: ImportWarning: can't
resolve package from __spec__ or __package__, falling back on __name__ and __path__`

I was unable to fix it at the level of my django installation or in djangosaml2idp. On closer inspection, it seems that symmetric.py is overriding all warnings settings back to default, meaning that ignoring them at a higher level wouldn't work.

As I was unable to find any information on why warnings are not being ignored in comments, commit history, or docs, I tried to go with the least invasive path I could find, and re-ignore just this kind of error. 

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



