### PR TITLE
Check the xmlsec returncode

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -728,10 +728,8 @@ class CryptoBackendXmlSec1(CryptoBackend):
             com_list.extend(['--node-xpath', xpath])
 
         (_stdout, _stderr, output) = self._run_xmlsec(
-            com_list,
-            [template],
-            exception=DecryptError,
-            validate_output=False)
+            com_list, [template], validate_output=False
+        )
 
         return output
 
@@ -773,10 +771,8 @@ class CryptoBackendXmlSec1(CryptoBackend):
             com_list.extend(['--node-id', node_id])
 
         (_stdout, _stderr, output) = self._run_xmlsec(
-            com_list,
-            [tmpl],
-            exception=EncryptError,
-            validate_output=False)
+            com_list, [tmpl], validate_output=False
+        )
 
         os.unlink(fil)
         if not output:
@@ -804,10 +800,8 @@ class CryptoBackendXmlSec1(CryptoBackend):
         ]
 
         (_stdout, _stderr, output) = self._run_xmlsec(
-            com_list,
-            [fil],
-            exception=DecryptError,
-            validate_output=False)
+            com_list, [fil], validate_output=False
+        )
         return output.decode('utf-8')
 
     def sign_statement(self, statement, node_name, key_file, node_id, id_attr):
@@ -844,9 +838,8 @@ class CryptoBackendXmlSec1(CryptoBackend):
 
         try:
             (stdout, stderr, signed_statement) = self._run_xmlsec(
-                com_list,
-                [fil],
-                validate_output=False)
+                com_list, [fil], validate_output=False
+            )
 
             # this doesn't work if --store-signatures are used
             if stdout == '':
@@ -891,21 +884,17 @@ class CryptoBackendXmlSec1(CryptoBackend):
         if node_id:
             com_list.extend(['--node-id', node_id])
 
-        (_stdout, stderr, _output) = self._run_xmlsec(
-            com_list,
-            [fil],
-            exception=SignatureError)
+        (_stdout, stderr, _output) = self._run_xmlsec(com_list, [fil])
 
         return parse_xmlsec_output(stderr)
 
-    def _run_xmlsec(self, com_list, extra_args, validate_output=True, exception=XmlsecError):
+    def _run_xmlsec(self, com_list, extra_args, validate_output=True):
         """
         Common code to invoke xmlsec and parse the output.
         :param com_list: Key-value parameter list for xmlsec
         :param extra_args: Positional parameters to be appended after all
             key-value parameters
         :param validate_output: Parse and validate the output
-        :param exception: The exception class to raise on errors
         :result: Whatever xmlsec wrote to an --output temporary file
         """
         with NamedTemporaryFile(suffix='.xml', delete=self._xmlsec_delete_tmpfiles) as ntf:

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -592,7 +592,6 @@ def verify_redirect_signature(saml_msg, crypto, cert=None, sigkey=None):
 
 
 LOG_LINE = 60 * '=' + '\n%s\n' + 60 * '-' + '\n%s' + 60 * '='
-LOG_LINE_2 = 60 * '=' + '\n%s\n%s\n' + 60 * '-' + '\n%s' + 60 * '='
 
 
 def make_str(txt):
@@ -727,9 +726,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
         if xpath:
             com_list.extend(['--node-xpath', xpath])
 
-        (_stdout, _stderr, output) = self._run_xmlsec(
-            com_list, [template], validate_output=False
-        )
+        (_stdout, _stderr, output) = self._run_xmlsec(com_list, [template])
 
         return output
 
@@ -770,9 +767,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
         if node_id:
             com_list.extend(['--node-id', node_id])
 
-        (_stdout, _stderr, output) = self._run_xmlsec(
-            com_list, [tmpl], validate_output=False
-        )
+        (_stdout, _stderr, output) = self._run_xmlsec(com_list, [tmpl])
 
         os.unlink(fil)
         if not output:
@@ -799,9 +794,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
             ENC_KEY_CLASS,
         ]
 
-        (_stdout, _stderr, output) = self._run_xmlsec(
-            com_list, [fil], validate_output=False
-        )
+        (_stdout, _stderr, output) = self._run_xmlsec(com_list, [fil])
         return output.decode('utf-8')
 
     def sign_statement(self, statement, node_name, key_file, node_id, id_attr):
@@ -838,7 +831,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
 
         try:
             (stdout, stderr, signed_statement) = self._run_xmlsec(
-                com_list, [fil], validate_output=False
+                com_list, [fil]
             )
 
             # this doesn't work if --store-signatures are used
@@ -888,13 +881,12 @@ class CryptoBackendXmlSec1(CryptoBackend):
 
         return parse_xmlsec_output(stderr)
 
-    def _run_xmlsec(self, com_list, extra_args, validate_output=True):
+    def _run_xmlsec(self, com_list, extra_args):
         """
         Common code to invoke xmlsec and parse the output.
         :param com_list: Key-value parameter list for xmlsec
         :param extra_args: Positional parameters to be appended after all
             key-value parameters
-        :param validate_output: Parse and validate the output
         :result: Whatever xmlsec wrote to an --output temporary file
         """
         with NamedTemporaryFile(suffix='.xml', delete=self._xmlsec_delete_tmpfiles) as ntf:
@@ -912,13 +904,6 @@ class CryptoBackendXmlSec1(CryptoBackend):
                 logger.error(LOG_LINE, p_out, p_err)
                 raise XmlsecError('{err_code}:{err_msg}'.format(
                     err_code=pof.returncode, err_msg=p_err))
-
-            try:
-                if validate_output:
-                    parse_xmlsec_output(p_err)
-            except XmlsecError as exc:
-                logger.error(LOG_LINE_2, p_out, p_err, exc)
-                raise
 
             ntf.seek(0)
             return p_out, p_err, ntf.read()

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -678,10 +678,9 @@ class CryptoBackendXmlSec1(CryptoBackend):
         CryptoBackend.__init__(self, **kwargs)
         assert (isinstance(xmlsec_binary, six.string_types))
         self.xmlsec = xmlsec_binary
-        if os.environ.get('PYSAML2_KEEP_XMLSEC_TMP', None):
-            self._xmlsec_delete_tmpfiles = False
-        else:
-            self._xmlsec_delete_tmpfiles = True
+        self._xmlsec_delete_tmpfiles = os.environ.get(
+            'PYSAML2_KEEP_XMLSEC_TMP', False
+        )
 
         try:
             self.non_xml_crypto = RSACrypto(kwargs['rsa_key'])
@@ -817,10 +816,11 @@ class CryptoBackendXmlSec1(CryptoBackend):
             statement = str(statement)
 
         _, fil = make_temp(
-                statement,
-                suffix='.xml',
-                decode=False,
-                delete=self._xmlsec_delete_tmpfiles)
+            statement,
+            suffix='.xml',
+            decode=False,
+            delete=self._xmlsec_delete_tmpfiles,
+        )
 
         com_list = [
             self.xmlsec,
@@ -864,10 +864,11 @@ class CryptoBackendXmlSec1(CryptoBackend):
             signedtext = signedtext.encode('utf-8')
 
         _, fil = make_temp(
-                signedtext,
-                suffix='.xml',
-                decode=False,
-                delete=self._xmlsec_delete_tmpfiles)
+            signedtext,
+            suffix='.xml',
+            decode=False,
+            delete=self._xmlsec_delete_tmpfiles,
+        )
 
         com_list = [
             self.xmlsec,
@@ -1461,11 +1462,14 @@ class SecurityContext(object):
 
             for cert in _certs:
                 if isinstance(cert, six.string_types):
-                    certs.append(make_temp(
-                        pem_format(cert),
-                        suffix='.pem',
-                        decode=False,
-                        delete=self._xmlsec_delete_tmpfiles))
+                    certs.append(
+                        make_temp(
+                            pem_format(cert),
+                            suffix='.pem',
+                            decode=False,
+                            delete=self._xmlsec_delete_tmpfiles,
+                        )
+                    )
                 else:
                     certs.append(cert)
         else:
@@ -1478,7 +1482,8 @@ class SecurityContext(object):
                     pem_format(cert),
                     suffix='.pem',
                     decode=False,
-                    delete=self._xmlsec_delete_tmpfiles)
+                    delete=self._xmlsec_delete_tmpfiles,
+                )
                 for cert in cert_from_instance(item)
             ]
         else:

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -835,19 +835,16 @@ class CryptoBackendXmlSec1(CryptoBackend):
             com_list.extend(['--node-id', node_id])
 
         try:
-            (stdout, stderr, signed_statement) = self._run_xmlsec(
-                com_list, [fil]
-            )
+            (stdout, stderr, output) = self._run_xmlsec(com_list, [fil])
+        except XmlsecError as e:
+            raise SignatureError(com_list)
 
-            # this doesn't work if --store-signatures are used
-            if stdout == '':
-                if signed_statement:
-                    return signed_statement.decode('utf-8')
-
-            logger.error('Signing operation failed :\nstdout : %s\nstderr : %s', stdout, stderr)
-            raise SigverError(stderr)
-        except DecryptError:
-            raise SigverError('Signing failed')
+        # this does not work if --store-signatures is used
+        if output:
+            return output.decode("utf-8")
+        if stdout:
+            return stdout.decode("utf-8")
+        raise SignatureError(stderr)
 
     def validate_signature(self, signedtext, cert_file, cert_type, node_name, node_id, id_attr):
         """

--- a/tests/test_40_sigver.py
+++ b/tests/test_40_sigver.py
@@ -24,6 +24,7 @@ from py.test import raises
 
 from pathutils import full_path
 
+
 SIGNED = full_path("saml_signed.xml")
 UNSIGNED = full_path("saml_unsigned.xml")
 SIMPLE_SAML_PHP_RESPONSE = full_path("simplesamlphp_authnresponse.xml")
@@ -35,6 +36,12 @@ PRIV_KEY = full_path("test.key")
 
 ENC_PUB_KEY = full_path("pki/test_1.crt")
 ENC_PRIV_KEY = full_path("pki/test.key")
+
+INVALID_KEY = full_path("non-existent.key")
+
+IDP_EXAMPLE = full_path("idp_example.xml")
+METADATA_CERT = full_path("metadata_cert.xml")
+
 
 def _eq(l1, l2):
     return set(l1) == set(l2)
@@ -721,7 +728,7 @@ class TestSecurityMetadata():
         conf = config.SPConfig()
         conf.load_file("server_conf")
         md = MetadataStore([saml, samlp], None, conf)
-        md.load("local", full_path("metadata_cert.xml"))
+        md.load("local", METADATA_CERT)
 
         conf.metadata = md
         conf.only_use_keys_in_metadata = False
@@ -742,7 +749,7 @@ class TestSecurityMetadataNonAsciiAva():
         conf = config.SPConfig()
         conf.load_file("server_conf")
         md = MetadataStore([saml, samlp], None, conf)
-        md.load("local", full_path("metadata_cert.xml"))
+        md.load("local", METADATA_CERT)
 
         conf.metadata = md
         conf.only_use_keys_in_metadata = False
@@ -762,7 +769,7 @@ def test_xbox():
     conf = config.SPConfig()
     conf.load_file("server_conf")
     md = MetadataStore([saml, samlp], None, conf)
-    md.load("local", full_path("idp_example.xml"))
+    md.load("local", IDP_EXAMPLE)
 
     conf.metadata = md
     conf.only_use_keys_in_metadata = False
@@ -773,41 +780,50 @@ def test_xbox():
         issue_instant="2009-10-30T13:20:28Z",
         signature=sigver.pre_signature_part("11111", sec.my_cert, 1),
         attribute_statement=do_attribute_statement(
-            {("", "", "surName"): ("Foo", ""),
-             ("", "", "givenName"): ("Bar", ""), })
+            {
+                ("", "", "surName"): ("Foo", ""),
+                ("", "", "givenName"): ("Bar", ""),
+            }
+        )
     )
 
-    sigass = sec.sign_statement(assertion, class_name(assertion),
-                                key_file=full_path("test.key"),
-                                node_id=assertion.id)
+    sigass = sec.sign_statement(
+        assertion,
+        class_name(assertion),
+        key_file=PRIV_KEY,
+        node_id=assertion.id,
+    )
 
     _ass0 = saml.assertion_from_string(sigass)
-
     encrypted_assertion = EncryptedAssertion()
     encrypted_assertion.add_extension_element(_ass0)
 
-    _, pre = make_temp(str(pre_encryption_part()).encode('utf-8'), decode=False)
+    _, pre = make_temp(
+        str(pre_encryption_part()).encode('utf-8'), decode=False
+    )
     enctext = sec.crypto.encrypt(
-        str(encrypted_assertion), conf.cert_file, pre, "des-192",
-        '/*[local-name()="EncryptedAssertion"]/*[local-name()="Assertion"]')
+        str(encrypted_assertion),
+        conf.cert_file,
+        pre,
+        "des-192",
+        '/*[local-name()="EncryptedAssertion"]/*[local-name()="Assertion"]',
+    )
 
     decr_text = sec.decrypt(enctext, key_file=PRIV_KEY)
     _seass = saml.encrypted_assertion_from_string(decr_text)
     assertions = []
-    assers = extension_elements_to_elements(_seass.extension_elements,
-                                            [saml, samlp])
-
-    sign_cert_file = full_path("test.pem")
+    assers = extension_elements_to_elements(
+        _seass.extension_elements, [saml, samlp]
+    )
 
     for ass in assers:
-        _ass = "%s" % ass
-        #_ass = _ass.replace('xsi:nil="true" ', '')
-        #assert sigass == _ass
-        _txt = sec.verify_signature(_ass, sign_cert_file,
-                                    node_name=class_name(assertion))
+        _txt = sec.verify_signature(
+            str(ass), PUB_KEY, node_name=class_name(assertion)
+        )
         if _txt:
             assertions.append(ass)
 
+    assert assertions
     print(assertions)
 
 
@@ -815,7 +831,7 @@ def test_xbox_non_ascii_ava():
     conf = config.SPConfig()
     conf.load_file("server_conf")
     md = MetadataStore([saml, samlp], None, conf)
-    md.load("local", full_path("idp_example.xml"))
+    md.load("local", IDP_EXAMPLE)
 
     conf.metadata = md
     conf.only_use_keys_in_metadata = False
@@ -826,41 +842,50 @@ def test_xbox_non_ascii_ava():
         issue_instant="2009-10-30T13:20:28Z",
         signature=sigver.pre_signature_part("11111", sec.my_cert, 1),
         attribute_statement=do_attribute_statement(
-            {("", "", "surName"): ("Föö", ""),
-             ("", "", "givenName"): ("Bär", ""), })
+            {
+                ("", "", "surName"): ("Föö", ""),
+                ("", "", "givenName"): ("Bär", ""),
+            }
+        )
     )
 
-    sigass = sec.sign_statement(assertion, class_name(assertion),
-                                key_file=full_path("test.key"),
-                                node_id=assertion.id)
+    sigass = sec.sign_statement(
+        assertion,
+        class_name(assertion),
+        key_file=PRIV_KEY,
+        node_id=assertion.id,
+    )
 
     _ass0 = saml.assertion_from_string(sigass)
-
     encrypted_assertion = EncryptedAssertion()
     encrypted_assertion.add_extension_element(_ass0)
 
-    _, pre = make_temp(str(pre_encryption_part()).encode('utf-8'), decode=False)
+    _, pre = make_temp(
+        str(pre_encryption_part()).encode('utf-8'), decode=False
+    )
     enctext = sec.crypto.encrypt(
-        str(encrypted_assertion), conf.cert_file, pre, "des-192",
-        '/*[local-name()="EncryptedAssertion"]/*[local-name()="Assertion"]')
+        str(encrypted_assertion),
+        conf.cert_file,
+        pre,
+        "des-192",
+        '/*[local-name()="EncryptedAssertion"]/*[local-name()="Assertion"]',
+    )
 
     decr_text = sec.decrypt(enctext, key_file=PRIV_KEY)
     _seass = saml.encrypted_assertion_from_string(decr_text)
     assertions = []
-    assers = extension_elements_to_elements(_seass.extension_elements,
-                                            [saml, samlp])
-
-    sign_cert_file = full_path("test.pem")
+    assers = extension_elements_to_elements(
+        _seass.extension_elements, [saml, samlp]
+    )
 
     for ass in assers:
-        _ass = "%s" % ass
-        #_ass = _ass.replace('xsi:nil="true" ', '')
-        #assert sigass == _ass
-        _txt = sec.verify_signature(_ass, sign_cert_file,
-                                    node_name=class_name(assertion))
+        _txt = sec.verify_signature(
+            str(ass), PUB_KEY, node_name=class_name(assertion)
+        )
         if _txt:
             assertions.append(ass)
 
+    assert assertions
     print(assertions)
 
 
@@ -869,7 +894,7 @@ def test_okta():
     conf.load_file("server_conf")
     conf.id_attr_name = 'Id'
     md = MetadataStore([saml, samlp], None, conf)
-    md.load("local", full_path("idp_example.xml"))
+    md.load("local", IDP_EXAMPLE)
 
     conf.metadata = md
     conf.only_use_keys_in_metadata = False
@@ -892,7 +917,7 @@ def test_xmlsec_err():
     conf = config.SPConfig()
     conf.load_file("server_conf")
     md = MetadataStore([saml, samlp], None, conf)
-    md.load("local", full_path("idp_example.xml"))
+    md.load("local", IDP_EXAMPLE)
 
     conf.metadata = md
     conf.only_use_keys_in_metadata = False
@@ -909,7 +934,7 @@ def test_xmlsec_err():
 
     try:
         sec.sign_statement(assertion, class_name(assertion),
-                           key_file=full_path("tes.key"),
+                           key_file=INVALID_KEY,
                            node_id=assertion.id)
     except (XmlsecError, SigverError) as err:  # should throw an exception
         pass
@@ -921,7 +946,7 @@ def test_xmlsec_err_non_ascii_ava():
     conf = config.SPConfig()
     conf.load_file("server_conf")
     md = MetadataStore([saml, samlp], None, conf)
-    md.load("local", full_path("idp_example.xml"))
+    md.load("local", IDP_EXAMPLE)
 
     conf.metadata = md
     conf.only_use_keys_in_metadata = False
@@ -938,7 +963,7 @@ def test_xmlsec_err_non_ascii_ava():
 
     try:
         sec.sign_statement(assertion, class_name(assertion),
-                           key_file=full_path("tes.key"),
+                           key_file=INVALID_KEY,
                            node_id=assertion.id)
     except (XmlsecError, SigverError) as err:  # should throw an exception
         pass
@@ -950,7 +975,7 @@ def test_sha256_signing():
     conf = config.SPConfig()
     conf.load_file("server_conf")
     md = MetadataStore([saml, samlp], None, conf)
-    md.load("local", full_path("idp_example.xml"))
+    md.load("local", IDP_EXAMPLE)
 
     conf.metadata = md
     conf.only_use_keys_in_metadata = False
@@ -967,7 +992,7 @@ def test_sha256_signing():
     )
 
     s = sec.sign_statement(assertion, class_name(assertion),
-                           key_file=full_path("test.key"),
+                           key_file=PRIV_KEY,
                            node_id=assertion.id)
     assert s
 
@@ -976,7 +1001,7 @@ def test_sha256_signing_non_ascii_ava():
     conf = config.SPConfig()
     conf.load_file("server_conf")
     md = MetadataStore([saml, samlp], None, conf)
-    md.load("local", full_path("idp_example.xml"))
+    md.load("local", IDP_EXAMPLE)
 
     conf.metadata = md
     conf.only_use_keys_in_metadata = False
@@ -993,7 +1018,7 @@ def test_sha256_signing_non_ascii_ava():
     )
 
     s = sec.sign_statement(assertion, class_name(assertion),
-                           key_file=full_path("test.key"),
+                           key_file=PRIV_KEY,
                            node_id=assertion.id)
     assert s
 

--- a/tests/test_40_sigver.py
+++ b/tests/test_40_sigver.py
@@ -932,14 +932,13 @@ def test_xmlsec_err():
              ("", "", "givenName"): ("Bar", ""), })
     )
 
-    try:
-        sec.sign_statement(assertion, class_name(assertion),
-                           key_file=INVALID_KEY,
-                           node_id=assertion.id)
-    except (XmlsecError, SigverError) as err:  # should throw an exception
-        pass
-    else:
-        assert False
+    with raises(XmlsecError):
+        sec.sign_statement(
+            assertion,
+            class_name(assertion),
+            key_file=INVALID_KEY,
+            node_id=assertion.id,
+        )
 
 
 def test_xmlsec_err_non_ascii_ava():
@@ -961,14 +960,13 @@ def test_xmlsec_err_non_ascii_ava():
              ("", "", "givenName"): ("Bär", ""), })
     )
 
-    try:
-        sec.sign_statement(assertion, class_name(assertion),
-                           key_file=INVALID_KEY,
-                           node_id=assertion.id)
-    except (XmlsecError, SigverError) as err:  # should throw an exception
-        pass
-    else:
-        assert False
+    with raises(XmlsecError):
+        sec.sign_statement(
+            assertion,
+            class_name(assertion),
+            key_file=INVALID_KEY,
+            node_id=assertion.id,
+        )
 
 
 def test_sha256_signing():

--- a/tests/test_40_sigver.py
+++ b/tests/test_40_sigver.py
@@ -791,7 +791,7 @@ def test_xbox():
         str(encrypted_assertion), conf.cert_file, pre, "des-192",
         '/*[local-name()="EncryptedAssertion"]/*[local-name()="Assertion"]')
 
-    decr_text = sec.decrypt(enctext)
+    decr_text = sec.decrypt(enctext, key_file=PRIV_KEY)
     _seass = saml.encrypted_assertion_from_string(decr_text)
     assertions = []
     assers = extension_elements_to_elements(_seass.extension_elements,
@@ -844,7 +844,7 @@ def test_xbox_non_ascii_ava():
         str(encrypted_assertion), conf.cert_file, pre, "des-192",
         '/*[local-name()="EncryptedAssertion"]/*[local-name()="Assertion"]')
 
-    decr_text = sec.decrypt(enctext)
+    decr_text = sec.decrypt(enctext, key_file=PRIV_KEY)
     _seass = saml.encrypted_assertion_from_string(decr_text)
     assertions = []
     assers = extension_elements_to_elements(_seass.extension_elements,

--- a/tests/test_42_enc.py
+++ b/tests/test_42_enc.py
@@ -73,7 +73,8 @@ def test_enc1():
 
     crypto = CryptoBackendXmlSec1(xmlsec_path)
     (_stdout, _stderr, output) = crypto._run_xmlsec(
-        com_list, [tmpl], exception=EncryptError, validate_output=False)
+        com_list, [tmpl], validate_output=False
+    )
 
     print(output)
     assert _stderr == ""

--- a/tests/test_42_enc.py
+++ b/tests/test_42_enc.py
@@ -72,9 +72,7 @@ def test_enc1():
                 "--node-xpath", ASSERT_XPATH]
 
     crypto = CryptoBackendXmlSec1(xmlsec_path)
-    (_stdout, _stderr, output) = crypto._run_xmlsec(
-        com_list, [tmpl], validate_output=False
-    )
+    (_stdout, _stderr, output) = crypto._run_xmlsec(com_list, [tmpl])
 
     print(output)
     assert _stderr == ""

--- a/tests/test_50_server.py
+++ b/tests/test_50_server.py
@@ -8,7 +8,7 @@ from six.moves.urllib.parse import parse_qs
 import uuid
 
 from saml2.cert import OpenSSLWrapper
-from saml2.sigver import make_temp, EncryptError, CertificateError
+from saml2.sigver import make_temp, DecryptError, EncryptError, CertificateError
 from saml2.assertion import Policy
 from saml2.authn_context import INTERNETPROTOCOLPASSWORD
 from saml2.saml import NameID, NAMEID_FORMAT_TRANSIENT
@@ -33,6 +33,7 @@ from saml2 import BINDING_HTTP_REDIRECT
 from py.test import raises
 from pathutils import full_path
 import saml2.xmldsig as ds
+
 
 nid = NameID(name_qualifier="foo", format=NAMEID_FORMAT_TRANSIENT,
              text="123456")
@@ -171,7 +172,7 @@ class TestServer1():
             assert attr1.attribute_value[0].text == "Derek"
             assert attr0.friendly_name == "sn"
             assert attr0.attribute_value[0].text == "Jeter"
-        # 
+
         subject = assertion.subject
         assert _eq(subject.keyswv(), ["text", "name_id"])
         assert subject.text == "_aaa"
@@ -613,9 +614,11 @@ class TestServer1():
 
         decr_text_old = copy.deepcopy("%s" % signed_resp)
 
-        decr_text = self.server.sec.decrypt(signed_resp, self.client.config.encryption_keypairs[0]["key_file"])
-
-        assert decr_text == decr_text_old
+        with raises(DecryptError):
+            decr_text = self.server.sec.decrypt(
+                signed_resp,
+                self.client.config.encryption_keypairs[0]["key_file"],
+            )
 
         decr_text = self.server.sec.decrypt(signed_resp, self.client.config.encryption_keypairs[1]["key_file"])
 
@@ -958,7 +961,7 @@ class TestServer1():
         self.verify_advice_assertion(resp, decr_text_2)
 
     def test_encrypted_response_8(self):
-        try:
+        with raises(EncryptError):
             _resp = self.server.create_authn_response(
                 self.ava,
                 "id12",  # in_response_to
@@ -973,13 +976,8 @@ class TestServer1():
                 encrypt_cert_advice="whatever",
                 encrypt_cert_assertion="whatever"
             )
-            assert False, "Must throw an exception"
-        except EncryptError as ex:
-            pass
-        except Exception as ex:
-            assert False, "Wrong exception!"
 
-        try:
+        with raises(EncryptError):
             _resp = self.server.create_authn_response(
                 self.ava,
                 "id12",  # in_response_to
@@ -993,13 +991,8 @@ class TestServer1():
                 pefim=True,
                 encrypt_cert_advice="whatever",
             )
-            assert False, "Must throw an exception"
-        except EncryptError as ex:
-            pass
-        except Exception as ex:
-            assert False, "Wrong exception!"
 
-        try:
+        with raises(EncryptError):
             _resp = self.server.create_authn_response(
                 self.ava,
                 "id12",  # in_response_to
@@ -1013,15 +1006,10 @@ class TestServer1():
                 encrypted_advice_attributes=False,
                 encrypt_cert_assertion="whatever"
             )
-            assert False, "Must throw an exception"
-        except EncryptError as ex:
-            pass
-        except Exception as ex:
-            assert False, "Wrong exception!"
 
         _server = Server("idp_conf_verify_cert")
 
-        try:
+        with raises(CertificateError):
             _resp = _server.create_authn_response(
                 self.ava,
                 "id12",  # in_response_to
@@ -1036,13 +1024,8 @@ class TestServer1():
                 encrypt_cert_advice="whatever",
                 encrypt_cert_assertion="whatever"
             )
-            assert False, "Must throw an exception"
-        except CertificateError as ex:
-            pass
-        except Exception as ex:
-            assert False, "Wrong exception!"
 
-        try:
+        with raises(CertificateError):
             _resp = _server.create_authn_response(
                 self.ava,
                 "id12",  # in_response_to
@@ -1056,13 +1039,8 @@ class TestServer1():
                 pefim=True,
                 encrypt_cert_advice="whatever",
             )
-            assert False, "Must throw an exception"
-        except CertificateError as ex:
-            pass
-        except Exception as ex:
-            assert False, "Wrong exception!"
 
-        try:
+        with raises(CertificateError):
             _resp = _server.create_authn_response(
                 self.ava,
                 "id12",  # in_response_to
@@ -1076,11 +1054,6 @@ class TestServer1():
                 encrypted_advice_attributes=False,
                 encrypt_cert_assertion="whatever"
             )
-            assert False, "Must throw an exception"
-        except CertificateError as ex:
-            pass
-        except Exception as ex:
-            assert False, "Wrong exception!"
 
     def test_encrypted_response_9(self):
         _server = Server("idp_conf_sp_no_encrypt")
@@ -1715,9 +1688,11 @@ class TestServer1NonAsciiAva():
 
         decr_text_old = copy.deepcopy("%s" % signed_resp)
 
-        decr_text = self.server.sec.decrypt(signed_resp, self.client.config.encryption_keypairs[0]["key_file"])
-
-        assert decr_text == decr_text_old
+        with raises(DecryptError):
+            decr_text = self.server.sec.decrypt(
+                signed_resp,
+                self.client.config.encryption_keypairs[0]["key_file"],
+            )
 
         decr_text = self.server.sec.decrypt(signed_resp, self.client.config.encryption_keypairs[1]["key_file"])
 


### PR DESCRIPTION
There are two mechanisms that check for error cases of the `xmlsec1` operations invoked by pysaml2.

1. the function 'parse_xmlsec_output':
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L467-L479
The check itself is a bit silly, as it depends on finding a (complete) line on the output stream matching `OK` or `FAIL`:
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L901
and then, the check itself is not invoked for every invocation of `_run_xmlsec` - it is only called (twice) for `validate_signature`:
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L861

2. checks for empty output - invocations of xmlsec1 expect the output stream to be the result of the operation.
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L782-L783
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L852-L857

What exactly comes out of xmlsec1 with a return code greater than 0? This is the main function for xmlsec1:
https://github.com/lsh123/xmlsec/blob/5f6ce2c2f6f1f9692d626f371b3302a0a20dc94b/apps/xmlsec.c#L905-L1115
return code is set to 1:
https://github.com/lsh123/xmlsec/blob/5f6ce2c2f6f1f9692d626f371b3302a0a20dc94b/apps/xmlsec.c#L909
and only changes when the execution is successful (goto success):
https://github.com/lsh123/xmlsec/blob/5f6ce2c2f6f1f9692d626f371b3302a0a20dc94b/apps/xmlsec.c#L1105-L1106
In every other case (goto fail), the return code stays 1. This means, that every invocation of xmlsec1 that can fail will have return code 1, and this (when the backend is set to xmlsec) will not be noticed by pysaml2, unless the output is empty (which is checked only in some cases).

Ofcourse, pysaml2 is not a proxy to every possible command that xmlsec1 supports, but it uses xmlsec1 only for a few commands.
* `xmlsec --encrypt <message>` no checks, use the output
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L719-L728
* `xmlsec --encrypt <an-assertion>` check if output is empty
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L763-L773
* `xmlsec --decrypt` no checks, use the output
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L798-L804
* `xmlsec --sign` check if output is empty
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L834-L843
* `xmlsec --verify <some-signature>` check if output contains 'OK' or 'FAIL'
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L882-L892

These "kind-of" safe checks leaves us with the encrypt-message and decrypt operations where no checks are being made. Fixing the code makes some tests that fail, as part of a decrypt operation. By checking the return code we know there's a problem early in the process and we can raise an exception. Without checking the return code, the operation would still fail but result to an empty output. No checks are made, so, this value would be used as the result of the decrypted ciphertext and would be propagated to the callers. The top level operation controller SecurityContext::decrypt will check for an empty result and consider it a failed decryption, then proceed to try to decrypt the ciphertext with another key:
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L1410
Note, even when all keys fail to decrypt the ciphertext, the result is not a failure, but the ciphertext itself, which is then considered to be the plaintext..
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L1417
For encrypt, this check does not happen, but I haven't looked the callchain to check if the callers do:
https://github.com/IdentityPython/pysaml2/blob/435ae0176f917b089f6ed7de9c866b7b99ad8097/src/saml2/sigver.py#L1350

This leaves me with the impression that things are not that bad, but this is mostly by luck, not by design. This could be a serious security issue and begs for refactoring.


## Properly fixing the issue.

To fix the issue we could, as you suggested, check if the returncode is greater than 0 and then fail. I would question why we need to check for both None and another value. Per the subprocess module documentation for returncode: 
> A None value indicates that the process hasn’t terminated yet.
This probably has to do with backgrounded processes, which we do not invoke. The only thing we want to do, is to make sure the execution was successful, that is check that the return code is 0 - nothing more.
https://docs.python.org/3/library/subprocess.html#subprocess.Popen.returncode
Then, I would suspect that this is something very common and surely someone made this a common utility check. Indeed subprocess provides the following:
- The check_call function:
https://docs.python.org/3/library/subprocess.html#subprocess.check_call
- The check_output function:
https://docs.python.org/3/library/subprocess.html#subprocess.check_output
- and finally, replace the old Popen API with the run function:
https://docs.python.org/3/library/subprocess.html#subprocess.run
The run function returns an object that has the check_returncode method:
https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess.check_returncode
or run itself can be passed the `check=True` option
> If check is true, and the process exits with a non-zero exit code, a CalledProcessError exception will be raised. Attributes of that exception hold the arguments, the exit code, and stdout and stderr if they were captured.

---

Fixes #578 

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?