### PR TITLE
Python 3 problem with lxml.etree.tostring

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -957,7 +957,10 @@ class CryptoBackendXMLSecurity(CryptoBackend):
 
         xml = xmlsec.parse_xml(statement)
         signed = xmlsec.sign(xml, key_file)
-        return lxml.etree.tostring(signed, xml_declaration=True)
+        signed_str = lxml.etree.tostring(signed, xml_declaration=False, encoding="UTF-8")
+        if not isinstance(signed_str, six.string_types):
+            signed_str = signed_str.decode("utf-8")
+        return signed_str
 
     def validate_signature(self, signedtext, cert_file, cert_type, node_name, node_id, id_attr):
         """


### PR DESCRIPTION
Using tostring without encoding in python 3 results in a unparsable
xml_declaration.

```
b'<?xml version=\'1.0\' encoding=\'ASCII\'?>\n<ns0:Response
xmlns:ns0="urn:oasis:names:tc:SAML:2.0:protocol" ...
```

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



