### PR TITLE
 Add encoding setting

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -776,10 +776,6 @@ class CryptoBackendXmlSec1(CryptoBackend):
         except XmlsecError as e:
             six.raise_from(EncryptError(com_list), e)
 
-        os.unlink(fil)
-        if not output:
-            raise EncryptError(_stderr)
-
         return output.decode(encoding=ENCODING)
 
     def decrypt(self, enctext, key_file, id_attr):


### PR DESCRIPTION
When setting Japanese as an attribute, an error occurs, so the user can freely specify the encoding.

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



