### PR TITLE
Add xsd date type

### DIFF
--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -4,6 +4,7 @@
 # Generated Mon May  2 14:23:33 2011 by parse_xsd.py version 0.4.
 #
 import base64
+import datetime
 
 from saml2.validate import valid_ipv4, MustValueError
 from saml2.validate import valid_ipv6
@@ -196,6 +197,11 @@ class AttributeValueBase(SamlBase):
             'string': {
                 'type': str,
                 'to_type': str,
+                'to_text': str,
+            },
+            'date': {
+                'type': datetime.date,
+                'to_type': lambda x: datetime.datetime.strptime(x, '%Y-%m-%d').date(),
                 'to_text': str,
             },
             'integer': {


### PR DESCRIPTION
This PR is needed for returning attributes like
````
          <saml:Attribute Name="dateOfBirth">
            <saml:AttributeValue xsi:type="xs:date">2015-12-06</saml:AttributeValue>
          </saml:Attribute>
 ````

Otherwise I get an ValueError Exception like
````
Type and value do not match: date:<class 'str'>:2015-12-06
````
because `type(value) is not valid_type == True`

I didn't write any unit test, just tested in my context.

I also think that the following code https://github.com/IdentityPython/pysaml2/pull/602/files#diff-6c156669cad61eda35e679329251dce9R197 could be also improved according to https://github.com/IdentityPython/pysaml2/pull/518 if you agree.

