### PR TITLE
[DeprecationWarning] Fixed: cgi.escape is deprecated, use html.escape instead

### DIFF
--- a/src/saml2/pack.py
+++ b/src/saml2/pack.py
@@ -8,7 +8,10 @@ Bindings normally consists of three parts:
 """
 
 import base64
-import cgi
+# [DeprecationWarning] Fixed: cgi.escape is deprecated, use html.escape instead
+try: import html
+except: import cgi as html
+
 import logging
 
 import saml2
@@ -87,15 +90,15 @@ def http_form_post_message(message, location, relay_state="",
     _msg = _msg.decode('ascii')
 
     saml_response_input = HTML_INPUT_ELEMENT_SPEC.format(
-            name=cgi.escape(typ),
-            val=cgi.escape(_msg),
+            name=html.escape(typ),
+            val=html.escape(_msg),
             type='hidden')
 
     relay_state_input = ""
     if relay_state:
         relay_state_input = HTML_INPUT_ELEMENT_SPEC.format(
                 name='RelayState',
-                val=cgi.escape(relay_state),
+                val=html.escape(relay_state),
                 type='hidden')
 
     response = HTML_FORM_SPEC.format(

--- a/src/saml2/pack.py
+++ b/src/saml2/pack.py
@@ -68,6 +68,10 @@ HTML_FORM_SPEC = """<!DOCTYPE html>
 </html>"""
 
 
+def _html_escape(payload):
+    return html.escape(payload, quote=True)
+
+
 def http_form_post_message(message, location, relay_state="",
                            typ="SAMLRequest", **kwargs):
     """The HTTP POST binding defines a mechanism by which SAML protocol
@@ -91,15 +95,15 @@ def http_form_post_message(message, location, relay_state="",
     _msg = _msg.decode('ascii')
 
     saml_response_input = HTML_INPUT_ELEMENT_SPEC.format(
-            name=html.escape(typ),
-            val=html.escape(_msg),
+            name=_html_escape(typ),
+            val=_html_escape(_msg),
             type='hidden')
 
     relay_state_input = ""
     if relay_state:
         relay_state_input = HTML_INPUT_ELEMENT_SPEC.format(
                 name='RelayState',
-                val=html.escape(relay_state),
+                val=_html_escape(relay_state),
                 type='hidden')
 
     response = HTML_FORM_SPEC.format(

--- a/src/saml2/pack.py
+++ b/src/saml2/pack.py
@@ -8,9 +8,10 @@ Bindings normally consists of three parts:
 """
 
 import base64
-# [DeprecationWarning] Fixed: cgi.escape is deprecated, use html.escape instead
-try: import html
-except: import cgi as html
+try:
+    import html
+except:
+    import cgi as html
 
 import logging
 


### PR DESCRIPTION
This PR fixes these warnings:

````
[pid: 11360|app: 0|req: 1/1] 192.168.27.27 () {52 vars in 2146 bytes} [Fri Apr 26 09:50:06 2019] POST /Saml2/sso/post => generated 178 bytes in 51 msecs (HTTP/1.1 303) 3 headers in 1465 bytes (1 switches on core 0)
/home/user/django-saml2-idp.env/lib/python3.7/site-packages/saml2/pack.py:90: DeprecationWarning: cgi.escape is deprecated, use html.escape instead
  name=cgi.escape(typ),
/home/user/django-saml2-idp.env/lib/python3.7/site-packages/saml2/pack.py:91: DeprecationWarning: cgi.escape is deprecated, use html.escape instead
  val=cgi.escape(_msg),
/home/user/django-saml2-idp.env/lib/python3.7/site-packages/saml2/pack.py:98: DeprecationWarning: cgi.escape is deprecated, use html.escape instead
````

I needed it to reduce logs size in time.

### Environment
Python 3.7.x

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



