### PR TITLE
CryptoBackendXmlSec1.decrypt now tries multiple id_attr names

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -789,7 +789,8 @@ class CryptoBackendXmlSec1(CryptoBackend):
         logger.debug('Decrypt input len: %d', len(enctext))
         _, fil = make_temp(enctext, decode=False)
 
-        # Deal with the various id_attr names found in the wild
+        # Try initially with the id_attr provided as a parameter, then
+        # if that fails, retry using the common variant attr-name values.
         for id_attr_name in (id_attr, 'ID', 'Id', 'id'):
             com_list = [
                 self.xmlsec,

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -785,9 +785,9 @@ class CryptoBackendXmlSec1(CryptoBackend):
         :param key_file: The key to use for the decryption
         :return: The decrypted document
         """
-
         logger.debug('Decrypt input len: %d', len(enctext))
         _, fil = make_temp(enctext, decode=False)
+        error = None
 
         # Try initially with the id_attr provided as a parameter, then
         # if that fails, retry using the common variant attr-name values.
@@ -805,15 +805,15 @@ class CryptoBackendXmlSec1(CryptoBackend):
             except XmlsecError as e:
                 logger.exception('Error decrypting with '
                                  'id_attr {}'.format(id_attr_name))
+                error = e
             else:
                 logger.info('Successful decryption with '
                             'id_attr {}'.format(id_attr_name))
-                e = False
+                error = None
                 break
-        if e:
-            six.raise_from(DecryptError(com_list), e)
+        if error:
+            six.raise_from(DecryptError(com_list), error)
         return output.decode('utf-8')
-
 
     def sign_statement(self, statement, node_name, key_file, node_id, id_attr):
         """

--- a/tests/test_40_sigver.py
+++ b/tests/test_40_sigver.py
@@ -13,7 +13,7 @@ from saml2 import saml, samlp
 from saml2 import config
 from saml2.sigver import pre_encryption_part
 from saml2.sigver import make_temp
-from saml2.sigver import XmlsecError
+from saml2.sigver import XmlsecError, DecryptError
 from saml2.mdstore import MetadataStore
 from saml2.saml import assertion_from_string
 from saml2.saml import EncryptedAssertion
@@ -1042,33 +1042,25 @@ def test_xmlsec_output_line_parsing():
     raises(sigver.XmlsecError, sigver.parse_xmlsec_output, output4)
 
 
-def test_xmlsec_decrypt_retry_logic():
-    """Ensure the CryptoBackendXmlSec1.decrypt retry works as expected."""
-
+@pytest.fixture()
+def xmlsec_crypto_backend():
+    """
+    Fixture for an instance of CryptoBackendXmlSec1.
+    """
     from contextlib import closing
-    from saml2.authn_context import INTERNETPROTOCOLPASSWORD
+
     from saml2.server import Server
-    from saml2.sigver import ASSERT_XPATH
     from saml2.sigver import CryptoBackendXmlSec1
-    from saml2.sigver import DecryptError
     from saml2.sigver import pre_encrypt_assertion
     from pathutils import xmlsec_path
     from pathutils import full_path
 
-    __author__ = 'roland'
-
-    TMPL_NO_HEADER = """<ns0:EncryptedData xmlns:ns0="http://www.w3.org/2001/04/xmlenc#" xmlns:ns1="http://www.w3.org/2000/09/xmldsig#" Id="ED" Type="http://www.w3.org/2001/04/xmlenc#Element"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc" /><ns1:KeyInfo><ns0:EncryptedKey Id="EK"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5" /><ns1:KeyInfo><ns1:KeyName>my-rsa-key</ns1:KeyName></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedKey></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedData>"""
-    TMPL = "<?xml version='1.0' encoding='UTF-8'?>\n%s" % TMPL_NO_HEADER
 
     IDENTITY = {"eduPersonAffiliation": ["staff", "member"],
                 "surName": ["Jeter"], "givenName": ["Derek"],
                 "mail": ["foo@gmail.com"],
                 "title": ["shortstop"]}
 
-    AUTHN = {
-        "class_ref": INTERNETPROTOCOLPASSWORD,
-        "authn_auth": "http://www.example.com/login"
-    }
     conf = config.SPConfig()
     conf.load_file("server_conf")
     md = MetadataStore([saml, samlp], None, conf)
@@ -1076,7 +1068,6 @@ def test_xmlsec_decrypt_retry_logic():
 
     conf.metadata = md
     conf.only_use_keys_in_metadata = False
-    sec = sigver.security_context(conf)
 
     with closing(Server("idp_conf")) as server:
         name_id = server.ident.transient_nameid(
@@ -1086,31 +1077,48 @@ def test_xmlsec_decrypt_retry_logic():
             IDENTITY, "id12", "http://lingon.catalogix.se:8087/",
             "urn:mace:example.com:saml:roland:sp", name_id=name_id)
 
-    statement = pre_encrypt_assertion(resp_)
+    pre_encrypt_assertion(resp_)
 
-    tmpl = full_path("enc_tmpl.xml")
+    full_path("enc_tmpl.xml")
 
-    data = full_path("pre_enc.xml")
+    return CryptoBackendXmlSec1(xmlsec_path)
 
-    key_type = "des-192"
-    com_list = [xmlsec_path, "encrypt", "--pubkey-cert-pem", full_path("pubkey.pem"),
-                "--session-key", key_type, "--xml-data", data,
-                "--node-xpath", ASSERT_XPATH]
 
-    crypto = CryptoBackendXmlSec1(xmlsec_path)
+@pytest.mark.parametrize(
+    "side_effects, expected_value, expected_error",
+    [
+        # Successful decryption on first try; no need for retries
+        ([('', '', b'some_xml')], 'some_xml', None),
+        # Error on the first try, but decrypt works on 2nd try
+        ([XmlsecError(), ('', '', b'some_xml')], 'some_xml', None),
+        # Errors on the first 3 tries followed by successful decryption
+        ([XmlsecError(), XmlsecError(), XmlsecError(), ('', '', b'some_xml')],
+                                                        'some_xml', None),
+        # Errors beyond the number of retries
+        ([XmlsecError(),] * 10, None, DecryptError()),
+    ],
+)
+def test_xmlsec_decrypt_retry_logic(xmlsec_crypto_backend, side_effects,
+                                    expected_value, expected_error):
+    """
+    Validate retry logic for CryptoBackendXmlSec1.decrypt.
 
-    with mock.patch('saml2.sigver.CryptoBackendXmlSec1._run_xmlsec',
-                    return_value=('', '', b'some_xml')) as mock_run_xmlsec:
+    This test checks for expected retry and error handling logic,
+    rather than the actual decryption.
+    """
 
-        output = crypto.decrypt(enctext='fadfsdfd', key_file='/nonexistent',
-                                id_attr='Id')
-        assert 'some_xml' in output
-
-        mock_run_xmlsec.side_effect = XmlsecError()
-        with pytest.raises(DecryptError):
-            crypto.decrypt(enctext='fadfsdfd',
-                                    key_file='/nonexistent',
-                                    id_attr='Id')
+    with mock.patch('saml2.sigver.CryptoBackendXmlSec1._run_xmlsec') as mock_run_xmlsec:
+        mock_run_xmlsec.side_effect = side_effects
+        if expected_error:
+            with pytest.raises(DecryptError):
+                xmlsec_crypto_backend.decrypt(enctext='fadfsdfd',
+                                              key_file='/nonexistent',
+                                              id_attr='Id')
+        else:
+            output = xmlsec_crypto_backend.decrypt(enctext='fadfsdfd',
+                                                   key_file='/nonexistent',
+                                                   id_attr='Id')
+            assert expected_value in output
 
 
 if __name__ == "__main__":

--- a/tests/test_40_sigver.py
+++ b/tests/test_40_sigver.py
@@ -890,9 +890,15 @@ def test_xbox_non_ascii_ava():
 
 
 def test_okta():
+    """Okta encrypted assertions have to be decrypted using non-default
+    parameters for xmlsec1.
+
+    This test validates that the decryption retry mechanism will try the
+    needed "id-attr=Id" parameter and successfully decrypt the message
+    with no need for special configuration.
+    """
     conf = config.Config()
     conf.load_file("server_conf")
-    conf.id_attr_name = 'Id'
     md = MetadataStore([saml, samlp], None, conf)
     md.load("local", IDP_EXAMPLE)
 


### PR DESCRIPTION
Because IdPs in the wild may use different id-attr values, try decrypting using xmlsec with multiple different --id-attr params rather than giving up after a single attempt to decrypt SAML assertions.

Sometimes a single SAML service provider must support multiple IdPs using a single common pysaml2 configuration, and these IdPs might use variant ID attributes when encrypting assertions. In that scenario, the 'id_attr_name' attribute configuration for pysaml2 config can't support those IdP variations.

This approach also has the advantage of reducing tedium by requiring one less configuration attribute for service provider implementers to have to worry about.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
    -- I have also modified one test, showing that it is no longer necessary to specify id_attr_name
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



