### PR TITLE
Explicit cherrypy requirements for the example application

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,2 +1,2 @@
 mako
-cherrypy
+cherrypy>14.0.2


### PR DESCRIPTION
Unless you are pulling always from https://pypi.org/simple, it is possible
that you might get an older version of `cherrypy`.

Make sure we request a "relatively recent" version.
`pip install 'CherryPy>14.0.2,<15'` gave `CherryPy-14.2.0` which works

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] ~~Have you written new tests for your changes?~~ _not required, tested manually_
* [x] Does your submission pass tests?
* [ ] ~~This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?~~ _not required, no python file changed_



