### PR TITLE
Allow NameQualifier and SPNameQualifier attributes to be set for ePTID

### DIFF
--- a/tests/test_19_attribute_converter.py
+++ b/tests/test_19_attribute_converter.py
@@ -222,13 +222,18 @@ class TestAC():
         assert attributes[0].attribute_value[1].extension_elements[0].text == "test value2"
 
     def test_from_local_eduPersonTargetedID_with_qualifiers(self):
-        IDP_ENTITY_ID = 'https://some.org/idp'
-        SP_ENTITY_ID = 'https://some.org/sp'
+        IDP_ENTITY_ID = "https://some.org/idp"
+        SP_ENTITY_ID = "https://some.org/sp"
 
-        ava = {"edupersontargetedid": [{
-               'value': "test value1",
-               'NameQualifier': IDP_ENTITY_ID,
-               'SPNameQualifier': SP_ENTITY_ID}]}
+        ava = {
+            "edupersontargetedid": [
+                {
+                    "text": "test value1",
+                    "NameQualifier": IDP_ENTITY_ID,
+                    "SPNameQualifier": SP_ENTITY_ID,
+                }
+            ]
+        }
         attributes = from_local(self.acs, ava, URI_NF)
 
         assert len(attributes) == 1
@@ -236,8 +241,8 @@ class TestAC():
         element = attributes[0].attribute_value[0].extension_elements[0]
 
         assert element.text == "test value1"
-        assert element.attributes['NameQualifier'] == IDP_ENTITY_ID
-        assert element.attributes['SPNameQualifier'] == SP_ENTITY_ID
+        assert element.attributes["NameQualifier"] == IDP_ENTITY_ID
+        assert element.attributes["SPNameQualifier"] == SP_ENTITY_ID
 
 
 def test_noop_attribute_conversion():

--- a/tests/test_19_attribute_converter.py
+++ b/tests/test_19_attribute_converter.py
@@ -221,6 +221,24 @@ class TestAC():
         assert attributes[0].attribute_value[0].extension_elements[0].text == "test value1"
         assert attributes[0].attribute_value[1].extension_elements[0].text == "test value2"
 
+    def test_from_local_eduPersonTargetedID_with_qualifiers(self):
+        IDP_ENTITY_ID = 'https://some.org/idp'
+        SP_ENTITY_ID = 'https://some.org/sp'
+
+        ava = {"edupersontargetedid": [{
+               'value': "test value1",
+               'NameQualifier': IDP_ENTITY_ID,
+               'SPNameQualifier': SP_ENTITY_ID}]}
+        attributes = from_local(self.acs, ava, URI_NF)
+
+        assert len(attributes) == 1
+
+        element = attributes[0].attribute_value[0].extension_elements[0]
+
+        assert element.text == "test value1"
+        assert element.attributes['NameQualifier'] == IDP_ENTITY_ID
+        assert element.attributes['SPNameQualifier'] == SP_ENTITY_ID
+
 
 def test_noop_attribute_conversion():
     ava = {"urn:oid:2.5.4.4": "Roland", "urn:oid:2.5.4.42": "Hedberg"}


### PR DESCRIPTION
The attribute value for eduPersonTargetedID (ePTID) is a NameID
element. The SAML specification allows the NameID element to include
the two optional attributes 'NameQualifier' and 'SPNameQualifier'. This
patch enables specifying a dictionary as the internal or local attribute
value instead of a string. When the local attribute value is a
dictionary with keys 'value', 'NameQualifier', and 'SPNameQualifier'
then the resulting XML NameID element will include the 'NameQualifier'
and 'SPNameQualifier' attributes with values taken from the values
of the dictionary. The value for the NameID element is taken from the
value associated with tthe 'value' key.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



