### PR TITLE
Disabled weak algorithms following Kantara SAML V2.0 Implementation Profile

### DIFF
--- a/src/saml2/algsupport.py
+++ b/src/saml2/algsupport.py
@@ -6,7 +6,7 @@ from saml2.extension.algsupport import DigestMethod
 __author__ = 'roland'
 
 DIGEST_METHODS = {
-    "hmac-md5": 'http://www.w3.org/2001/04/xmldsig-more#md5', # test framework only!
+    #"hmac-md5": 'http://www.w3.org/2001/04/xmldsig-more#md5', # test framework only!
     "hmac-sha1": 'http://www.w3.org/2000/09/xmldsig#sha1',
     "hmac-sha224": 'http://www.w3.org/2001/04/xmldsig-more#sha224',
     "hmac-sha256": 'http://www.w3.org/2001/04/xmlenc#sha256',
@@ -16,7 +16,7 @@ DIGEST_METHODS = {
 }
 
 SIGNING_METHODS = {
-    "rsa-md5": 'http://www.w3.org/2001/04/xmldsig-more#rsa-md5',
+    #"rsa-md5": 'http://www.w3.org/2001/04/xmldsig-more#rsa-md5',
     "rsa-ripemd160": 'http://www.w3.org/2001/04/xmldsig-more#rsa-ripemd160',
     "rsa-sha1": 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
     "rsa-sha224": 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha224',


### PR DESCRIPTION
*Kantara SAML V2.0 Implementation Profile for Federation Interoperability* specifications:

````
[IIP-ALG08]
Implementations MUST support the ability to prevent the use of particular algorithms such that any attempt to configure or select them will result in failure. The set of such algorithms MUST be configurable and it is RECOMMENDED that the default set include:

Digest

http://www.w3.org/2001/04/xmldsig-more#md5 [RFC4051]

Signature

http://www.w3.org/2001/04/xmldsig-more#rsa-md5 [RFC4051]
````

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



