### PR TITLE
Fix IdP example list

### DIFF
--- a/docs/examples/idp.rst
+++ b/docs/examples/idp.rst
@@ -4,6 +4,7 @@ An extremly simple example of a SAML2 identity provider.
 ========================================================
 
 There are 2 example IDPs in the project's example directory:
+
 * idp2 has a static definition of users:
  * user attributes are defined in idp_user.py
  * the password is defined in the PASSWD dict in idp.py


### PR DESCRIPTION
Fix the issue #630 that the list of IdP examples is not properly rendered in [An extremly simple example of a SAML2 identity provider](https://pysaml2.readthedocs.io/en/latest/examples/idp.html).

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? Yes
* [x] Have you added an explanation of what problem you are trying to solve with this PR? Yes
* [x] Have you added information on what your changes do and why you chose this as your solution? Yes-ish
* [ ] Have you written new tests for your changes? Not related
* [ ] Does your submission pass tests? Not related
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter? Not related



