### PR TITLE
Fix PKCS_9 url:oid prefix in attributemaps

### DIFF
--- a/example/attributemaps/saml_uri.py
+++ b/example/attributemaps/saml_uri.py
@@ -5,7 +5,7 @@ X500ATTR_OID = "urn:oid:2.5.4."
 NOREDUPERSON_OID = "urn:oid:1.3.6.1.4.1.2428.90.1."
 NETSCAPE_LDAP = "urn:oid:2.16.840.1.113730.3.1."
 UCL_DIR_PILOT = 'urn:oid:0.9.2342.19200300.100.1.'
-PKCS_9 = "urn:oid:1.2.840.113549.1.9.1."
+PKCS_9 = "urn:oid:1.2.840.113549.1.9."
 UMICH = "urn:oid:1.3.6.1.4.1.250.1.57."
 
 MAP = {


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc2985 the urn for emailAddress has to be `1.2.840.113549.1.9.1`.
In saml_uri.py this is not implemented correctly. The current version uses `PKCS_9+'1'` which equals to `1.2.840.113549.1.9.1.1`. This can be fixed by deleting the trailing `1.` from line 8. This should not cause any side-effects, because the variable `PKCS_9` is solely used in combination with `+'1'`.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



