### PR TITLE
Feature add metadata freshness

### DIFF
--- a/docs/howto/config.rst
+++ b/docs/howto/config.rst
@@ -208,6 +208,7 @@ For example::
             {
                 "url": "http://mdq.ukfederation.org.uk/",
                 "cert": "ukfederation-mdq.pem",
+                "freshness_period": "P0Y0M0DT2H0M0S",
             },
         ],
     },
@@ -219,6 +220,14 @@ downloaded from the remote server and the MDQ server local copies of the
 metadata signing certificates should be used.  These public keys must be
 acquired by some secure out-of-band method before being placed on the local
 file system.
+
+When using MDQ, the `freshness_period` option can be set to define
+a period for which the metadata fetched from the the MDQ server are considered
+fresh. After that period has passed the metadata are not valid anymore and must
+be fetched again. The period must be in the format defined in `iso 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_.
+
+By default, if `freshness_period` is not defined, the metadata are fetched
+only the first time they are requested and never refreshed.
 
 organization
 ^^^^^^^^^^^^

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -860,7 +860,7 @@ class MetaDataMDX(InMemoryMetaData):
             else:
                 logger.info("Metadata for {} have expired, refreshing "
                             "metadata".format(item))
-                self.entity.pop(item, None)
+                self.entity.pop(item)
                 entity = self.fetch_metadata(item)
         else:
             entity = self.fetch_metadata(item)

--- a/src/saml2/time_util.py
+++ b/src/saml2/time_util.py
@@ -140,19 +140,20 @@ def add_duration(tid, duration):
         carry = f_quotient(temp, 60)
         # hours
         temp = tid.tm_hour + dur["tm_hour"] + carry
-        hour = modulo(temp, 60)
-        carry = f_quotient(temp, 60)
+        hour = modulo(temp, 24)
+        carry = f_quotient(temp, 24)
         # days
-        if dur["tm_mday"] > maximum_day_in_month_for(year, month):
+        if tid.tm_mday > maximum_day_in_month_for(year, month):
             temp_days = maximum_day_in_month_for(year, month)
-        elif dur["tm_mday"] < 1:
+        elif tid.tm_mday < 1:
             temp_days = 1
         else:
-            temp_days = dur["tm_mday"]
-        days = temp_days + tid.tm_mday + carry
+            temp_days = tid.tm_mday
+        days = temp_days + dur["tm_mday"] + carry
         while True:
             if days < 1:
-                pass
+                days = days + maximum_day_in_month_for(year, month - 1)
+                carry = -1
             elif days > maximum_day_in_month_for(year, month):
                 days -= maximum_day_in_month_for(year, month)
                 carry = 1

--- a/tests/test_10_time_util.py
+++ b/tests/test_10_time_util.py
@@ -92,7 +92,7 @@ def test_parse_duration_n():
         assert d == _val
 
 def test_add_duration_1():
-    #2000-01-12T12:13:14Z	P1Y3M5DT7H10M3S	2001-04-17T19:23:17Z    
+    #2000-01-12T12:13:14Z	P1Y3M5DT7H10M3S	2001-04-17T19:23:17Z
     t = add_duration(str_to_time("2000-01-12T12:13:14Z"), "P1Y3M5DT7H10M3S")
     assert t.tm_year == 2001
     assert t.tm_mon == 4
@@ -107,7 +107,7 @@ def test_add_duration_2():
     t = add_duration(str_to_time("2000-01-12T00:00:00Z"), "PT33H")
     assert t.tm_year == 2000
     assert t.tm_mon == 1
-    assert t.tm_mday == 14
+    assert t.tm_mday == 13
     assert t.tm_hour == 9
     assert t.tm_min == 0
     assert t.tm_sec == 0
@@ -119,7 +119,7 @@ def test_str_to_time():
     #t = time.mktime(str_to_time("2000-01-12T00:00:00Z"))
     #assert t == 947631600.0
     #TODO: add something to show how this time was arrived at
-    # do this as an external method in the 
+    # do this as an external method in the
     assert t == 947635200
     # some IdPs omit the trailing Z, and SAML spec is unclear if it is actually required
     t = calendar.timegm(str_to_time("2000-01-12T00:00:00"))


### PR DESCRIPTION
Implements the feature of specifying a freshness period for which the metadata returned from the MDQ is valid. The period for which the metadata are considered fresh is a static configuration.

Ideally the freshness of the metadata should be inferred from the headers of the MDQ's response, but since this isn't supported yet in pyFF this should be good enough.

In addition it fixes a bug in time_util.py as it didn't properly implement the algorithm described in https://www.w3.org/TR/xmlschema-2/#adding-durations-to-dateTimes
### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



