### PR TITLE
Add attribute mapping for umbrellaID attributes

### DIFF
--- a/src/saml2/attributemaps/saml_uri.py
+++ b/src/saml2/attributemaps/saml_uri.py
@@ -29,7 +29,8 @@ SAML_SUBJECT_ID = 'urn:oasis:names:tc:SAML:attribute:'
 
 # umbrellaID specification - https://www.umbrellaid.org
 # https://github.com/Umbrella-Commiters/UmbrellaIdP3/blob/master/schema/99-user.ldif
-UMBRELLA_ID = 'urn:oid:1.3.6.1.4.1.42750.1.1.'
+UMBRELLA_EAAUser_ID = 'urn:oid:1.3.6.1.4.1.42750.1.1.'
+UMBRELLA_BridgeFederation_ID = 'urn:oid:1.3.6.1.4.1.42750.2.'
 
 MAP = {
     'identifier': 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
@@ -147,7 +148,16 @@ MAP = {
         UCL_DIR_PILOT+'37': 'associatedDomain',
         UCL_DIR_PILOT+'43': 'co',
         UCL_DIR_PILOT+'60': 'jpegPhoto',
-        UMBRELLA_ID+'1': 'EAAHash',
+        UMBRELLA_EAAUser_ID+'1': 'EAAHash',
+        UMBRELLA_EAAUser_ID+'2': 'EAABirthdate',
+        UMBRELLA_EAAUser_ID+'3': 'EAAKey',
+        UMBRELLA_EAAUser_ID+'4': 'EAAResetPWUUID',
+        UMBRELLA_EAAUser_ID+'5': 'EAAResetPwDate',
+        UMBRELLA_BridgeFederation_ID+'1': 'BridgeFederationSrc',
+        UMBRELLA_BridgeFederation_ID+'2': 'BridgeFederationUID',
+        UMBRELLA_BridgeFederation_ID+'3': 'BridgeFederationUmbrellaUID',
+        UMBRELLA_BridgeFederation_ID+'4': 'BridgeFederation',
+        UMBRELLA_BridgeFederation_ID+'5': 'BridgeFederationUmbrellaUsername',
         UMICH+'57': 'labeledURI',
         X500ATTR_OID+'2': 'knowledgeInformation',
         X500ATTR_OID+'3': 'cn',
@@ -236,7 +246,16 @@ MAP = {
         'displayName': NETSCAPE_LDAP+'241',
         'dmdName': X500ATTR_OID+'54',
         'dnQualifier': X500ATTR_OID+'46',
-        'EAAHash': UMBRELLA_ID+'1',
+        'EAAHash': UMBRELLA_EAAUser_ID+'1',
+        'EAABirthdate': UMBRELLA_EAAUser_ID+'2',
+        'EAAKey': UMBRELLA_EAAUser_ID+'3',
+        'EAAResetPWUUID': UMBRELLA_EAAUser_ID+'4',
+        'EAAResetPwDate': UMBRELLA_EAAUser_ID+'5',
+        'BridgeFederationSrc': UMBRELLA_BridgeFederation_ID+'1',
+        'BridgeFederationUID': UMBRELLA_BridgeFederation_ID+'2',
+        'BridgeFederationUmbrellaUID': UMBRELLA_BridgeFederation_ID+'3',
+        'BridgeFederation': UMBRELLA_BridgeFederation_ID+'4',
+        'BridgeFederationUmbrellaUsername': UMBRELLA_BridgeFederation_ID+'5',
         'eduCourseMember': EDUCOURSE_OID+'2',
         'eduCourseOffering': EDUCOURSE_OID+'1',
         'eduPersonAffiliation': EDUPERSON_OID+'1',

--- a/src/saml2/attributemaps/saml_uri.py
+++ b/src/saml2/attributemaps/saml_uri.py
@@ -29,7 +29,7 @@ SAML_SUBJECT_ID = 'urn:oasis:names:tc:SAML:attribute:'
 
 # umbrellaID specification - https://www.umbrellaid.org
 # https://github.com/Umbrella-Commiters/UmbrellaIdP3/blob/master/schema/99-user.ldif
-UMBRELLA_ID = 'urn:oid:1.3.6.1.4.1.42750.1.1'
+UMBRELLA_ID = 'urn:oid:1.3.6.1.4.1.42750.1.1.'
 
 MAP = {
     'identifier': 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',

--- a/src/saml2/attributemaps/saml_uri.py
+++ b/src/saml2/attributemaps/saml_uri.py
@@ -30,7 +30,6 @@ SAML_SUBJECT_ID = 'urn:oasis:names:tc:SAML:attribute:'
 # umbrellaID specification - https://www.umbrellaid.org
 # https://github.com/Umbrella-Commiters/UmbrellaIdP3/blob/master/schema/99-user.ldif
 UMBRELLA_EAAUser_ID = 'urn:oid:1.3.6.1.4.1.42750.1.1.'
-UMBRELLA_BridgeFederation_ID = 'urn:oid:1.3.6.1.4.1.42750.2.'
 
 MAP = {
     'identifier': 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
@@ -149,15 +148,7 @@ MAP = {
         UCL_DIR_PILOT+'43': 'co',
         UCL_DIR_PILOT+'60': 'jpegPhoto',
         UMBRELLA_EAAUser_ID+'1': 'EAAHash',
-        UMBRELLA_EAAUser_ID+'2': 'EAABirthdate',
         UMBRELLA_EAAUser_ID+'3': 'EAAKey',
-        UMBRELLA_EAAUser_ID+'4': 'EAAResetPWUUID',
-        UMBRELLA_EAAUser_ID+'5': 'EAAResetPwDate',
-        UMBRELLA_BridgeFederation_ID+'1': 'BridgeFederationSrc',
-        UMBRELLA_BridgeFederation_ID+'2': 'BridgeFederationUID',
-        UMBRELLA_BridgeFederation_ID+'3': 'BridgeFederationUmbrellaUID',
-        UMBRELLA_BridgeFederation_ID+'4': 'BridgeFederation',
-        UMBRELLA_BridgeFederation_ID+'5': 'BridgeFederationUmbrellaUsername',
         UMICH+'57': 'labeledURI',
         X500ATTR_OID+'2': 'knowledgeInformation',
         X500ATTR_OID+'3': 'cn',
@@ -247,15 +238,7 @@ MAP = {
         'dmdName': X500ATTR_OID+'54',
         'dnQualifier': X500ATTR_OID+'46',
         'EAAHash': UMBRELLA_EAAUser_ID+'1',
-        'EAABirthdate': UMBRELLA_EAAUser_ID+'2',
         'EAAKey': UMBRELLA_EAAUser_ID+'3',
-        'EAAResetPWUUID': UMBRELLA_EAAUser_ID+'4',
-        'EAAResetPwDate': UMBRELLA_EAAUser_ID+'5',
-        'BridgeFederationSrc': UMBRELLA_BridgeFederation_ID+'1',
-        'BridgeFederationUID': UMBRELLA_BridgeFederation_ID+'2',
-        'BridgeFederationUmbrellaUID': UMBRELLA_BridgeFederation_ID+'3',
-        'BridgeFederation': UMBRELLA_BridgeFederation_ID+'4',
-        'BridgeFederationUmbrellaUsername': UMBRELLA_BridgeFederation_ID+'5',
         'eduCourseMember': EDUCOURSE_OID+'2',
         'eduCourseOffering': EDUCOURSE_OID+'1',
         'eduPersonAffiliation': EDUPERSON_OID+'1',

--- a/src/saml2/attributemaps/saml_uri.py
+++ b/src/saml2/attributemaps/saml_uri.py
@@ -27,6 +27,10 @@ EIDAS_LEGALPERSON = 'http://eidas.europa.eu/attributes/legalperson/'
 # https://docs.oasis-open.org/security/saml-subject-id-attr/v1.0/cs01/saml-subject-id-attr-v1.0-cs01.html
 SAML_SUBJECT_ID = 'urn:oasis:names:tc:SAML:attribute:'
 
+# umbrellaID specification - https://www.umbrellaid.org
+# https://github.com/Umbrella-Commiters/UmbrellaIdP3/blob/master/schema/99-user.ldif
+UMBRELLA_ID = 'urn:oid:1.3.6.1.4.1.42750.1.1'
+
 MAP = {
     'identifier': 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
     'fro': {
@@ -143,6 +147,7 @@ MAP = {
         UCL_DIR_PILOT+'37': 'associatedDomain',
         UCL_DIR_PILOT+'43': 'co',
         UCL_DIR_PILOT+'60': 'jpegPhoto',
+        UMBRELLA_ID+'1': 'EAAHash',
         UMICH+'57': 'labeledURI',
         X500ATTR_OID+'2': 'knowledgeInformation',
         X500ATTR_OID+'3': 'cn',
@@ -231,6 +236,7 @@ MAP = {
         'displayName': NETSCAPE_LDAP+'241',
         'dmdName': X500ATTR_OID+'54',
         'dnQualifier': X500ATTR_OID+'46',
+        'EAAHash': UMBRELLA_ID+'1',
         'eduCourseMember': EDUCOURSE_OID+'2',
         'eduCourseOffering': EDUCOURSE_OID+'1',
         'eduPersonAffiliation': EDUPERSON_OID+'1',


### PR DESCRIPTION
umbrellaID is the federated identity system for the users of the
(European) large neutron and photon facilities.

This commit adds the mapping for the EAAHash, which is used for
identifying users in the umbrellaID AAI.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



