### PR TITLE
Adding documentation for centos/rhel 7

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,6 +25,10 @@ You also need xmlsec1 which you can download from http://www.aleksey.com/xmlsec/
 
 If you're on macOS, you can get xmlsec1 installed from MacPorts or Fink.
 
+If you're on rhel/centos 7 you will need to install xmlsec1 and xmlsec1-openssl
+
+    yum install xmlsec1 xmlsec1-openssl
+
 Depending on how you are going to use PySAML2 you might also need
 
 * Mako

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,7 +25,7 @@ You also need xmlsec1 which you can download from http://www.aleksey.com/xmlsec/
 
 If you're on macOS, you can get xmlsec1 installed from MacPorts or Fink.
 
-If you're on rhel/centos 7 you will need to install xmlsec1 and xmlsec1-openssl
+If you're on rhel/centos 7 you will need to install xmlsec1 and xmlsec1-openssl::
 
     yum install xmlsec1 xmlsec1-openssl
 


### PR DESCRIPTION
I installed xmlsec1 on my centos box, but could not figure out why it was failing. I found the explanation in an old stackoverflow entry to install xmlsec1-openssl as well and that fixed it. I figured it should be in the documentation.



