### PR TITLE
Fix xmlsec1 --id-attr option

### DIFF
--- a/tests/test_40_sigver.py
+++ b/tests/test_40_sigver.py
@@ -196,10 +196,8 @@ class TestSecurity():
     def test_multiple_signatures_assertion(self):
         ass = self._assertion
         # basic test with two of the same
-        to_sign = [(ass, ass.id, ''),
-                   (ass, ass.id, '')
-        ]
-        sign_ass = self.sec.multiple_signatures("%s" % ass, to_sign)
+        to_sign = [(ass, ass.id), (ass, ass.id)]
+        sign_ass = self.sec.multiple_signatures(str(ass), to_sign)
         sass = saml.assertion_from_string(sign_ass)
         assert _eq(sass.keyswv(), ['attribute_statement', 'issue_instant',
                                    'version', 'signature', 'id'])
@@ -223,10 +221,8 @@ class TestSecurity():
 
         # order is important, we can't validate if the signatures are made
         # in the reverse order
-        to_sign = [(self._assertion, self._assertion.id, ''),
-                   (response, response.id, '')]
-
-        s_response = self.sec.multiple_signatures("%s" % response, to_sign)
+        to_sign = [(self._assertion, self._assertion.id), (response, response.id)]
+        s_response = self.sec.multiple_signatures(str(response), to_sign)
         assert s_response is not None
         response = response_from_string(s_response)
 
@@ -491,10 +487,8 @@ class TestSecurityNonAsciiAva():
     def test_multiple_signatures_assertion(self):
         ass = self._assertion
         # basic test with two of the same
-        to_sign = [(ass, ass.id, ''),
-                   (ass, ass.id, '')
-        ]
-        sign_ass = self.sec.multiple_signatures("%s" % ass, to_sign)
+        to_sign = [(ass, ass.id), (ass, ass.id)]
+        sign_ass = self.sec.multiple_signatures(str(ass), to_sign)
         sass = saml.assertion_from_string(sign_ass)
         assert _eq(sass.keyswv(), ['attribute_statement', 'issue_instant',
                                    'version', 'signature', 'id'])
@@ -518,10 +512,8 @@ class TestSecurityNonAsciiAva():
 
         # order is important, we can't validate if the signatures are made
         # in the reverse order
-        to_sign = [(self._assertion, self._assertion.id, ''),
-                   (response, response.id, '')]
-
-        s_response = self.sec.multiple_signatures("%s" % response, to_sign)
+        to_sign = [(self._assertion, self._assertion.id), (response, response.id)]
+        s_response = self.sec.multiple_signatures(str(response), to_sign)
         assert s_response is not None
         response = response_from_string(s_response)
 

--- a/tests/test_42_enc.py
+++ b/tests/test_42_enc.py
@@ -25,7 +25,7 @@ AUTHN = {
 
 
 def test_pre_enc():
-    tmpl = pre_encryption_part()
+    tmpl = pre_encryption_part(encrypted_key_id="EK", encrypted_data_id="ED")
     print(tmpl)
     assert "%s" % tmpl in (TMPL_NO_HEADER, TMPL)
 

--- a/tests/test_50_server.py
+++ b/tests/test_50_server.py
@@ -468,15 +468,13 @@ class TestServer1():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
 
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-                                                 node_id=sresponse.assertion[0].id,
-                                                 id_attr="")
+                                                 node_id=sresponse.assertion[0].id)
         assert valid
 
         self.verify_assertion(sresponse.assertion)
@@ -497,8 +495,7 @@ class TestServer1():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
 
         assert sresponse.assertion[0].signature == None
@@ -523,8 +520,7 @@ class TestServer1():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-                                                 node_id=sresponse.assertion[0].id,
-                                                 id_attr="")
+                                                 node_id=sresponse.assertion[0].id)
         assert valid
 
         self.verify_assertion(sresponse.assertion)
@@ -552,14 +548,16 @@ class TestServer1():
         valid = self.server.sec.verify_signature(
             signed_resp, self.server.config.cert_file,
             node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-            node_id=sresponse.id, id_attr="")
+            node_id=sresponse.id
+        )
 
         assert valid
 
         valid = self.server.sec.verify_signature(
             signed_resp, self.server.config.cert_file,
             node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-            node_id=sresponse.assertion[0].id, id_attr="")
+            node_id=sresponse.assertion[0].id
+        )
 
         assert valid
 
@@ -583,8 +581,7 @@ class TestServer1():
         #valid = self.server.sec.verify_signature(decr_text,
         #                                         self.server.config.cert_file,
         #                                         node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-        #                                         node_id=assertion[0].id,
-        #                                         id_attr="")
+        #                                         node_id=assertion[0].id)
         assert valid
 
     def test_encrypted_signed_response_2(self):
@@ -607,8 +604,7 @@ class TestServer1():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
 
         decr_text_old = copy.deepcopy("%s" % signed_resp)
@@ -653,8 +649,7 @@ class TestServer1():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
 
         key_fd = make_temp(cert_key_str, decode=False)
@@ -667,8 +662,7 @@ class TestServer1():
         valid = self.server.sec.verify_signature(decr_text,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-                                                 node_id=resp.assertion[0].id,
-                                                 id_attr="")
+                                                 node_id=resp.assertion[0].id)
 
         assert valid
 
@@ -700,8 +694,7 @@ class TestServer1():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
 
         decr_text = self.server.sec.decrypt(signed_resp, self.client.config.encryption_keypairs[1]["key_file"])
@@ -713,8 +706,7 @@ class TestServer1():
         valid = self.server.sec.verify_signature(decr_text,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-                                                 node_id=resp.assertion[0].id,
-                                                 id_attr="")
+                                                 node_id=resp.assertion[0].id)
 
         assert valid
 
@@ -733,8 +725,7 @@ class TestServer1():
         #valid = self.server.sec.verify_signature(decr_text,
         #                                         self.server.config.cert_file,
         #                                         node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-        #                                         node_id=assertion[0].id,
-        #                                         id_attr="")
+        #                                         node_id=assertion[0].id)
         assert valid
 
     def test_encrypted_response_1(self):
@@ -1534,15 +1525,13 @@ class TestServer1NonAsciiAva():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
 
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-                                                 node_id=sresponse.assertion[0].id,
-                                                 id_attr="")
+                                                 node_id=sresponse.assertion[0].id)
         assert valid
 
         self.verify_assertion(sresponse.assertion)
@@ -1563,8 +1552,7 @@ class TestServer1NonAsciiAva():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
 
         assert sresponse.assertion[0].signature == None
@@ -1589,8 +1577,7 @@ class TestServer1NonAsciiAva():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-                                                 node_id=sresponse.assertion[0].id,
-                                                 id_attr="")
+                                                 node_id=sresponse.assertion[0].id)
         assert valid
 
         self.verify_assertion(sresponse.assertion)
@@ -1618,14 +1605,16 @@ class TestServer1NonAsciiAva():
         valid = self.server.sec.verify_signature(
             signed_resp, self.server.config.cert_file,
             node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-            node_id=sresponse.id, id_attr="")
+            node_id=sresponse.id,
+        )
 
         assert valid
 
         valid = self.server.sec.verify_signature(
             signed_resp, self.server.config.cert_file,
             node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-            node_id=sresponse.assertion[0].id, id_attr="")
+            node_id=sresponse.assertion[0].id,
+        )
 
         assert valid
 
@@ -1649,8 +1638,7 @@ class TestServer1NonAsciiAva():
         #valid = self.server.sec.verify_signature(decr_text,
         #                                         self.server.config.cert_file,
         #                                         node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-        #                                         node_id=assertion[0].id,
-        #                                         id_attr="")
+        #                                         node_id=assertion[0].id)
         assert valid
 
     def test_encrypted_signed_response_2(self):
@@ -1673,8 +1661,7 @@ class TestServer1NonAsciiAva():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
 
         decr_text_old = copy.deepcopy("%s" % signed_resp)
@@ -1719,8 +1706,7 @@ class TestServer1NonAsciiAva():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
 
         key_fd = make_temp(cert_key_str, decode=False)
@@ -1733,8 +1719,7 @@ class TestServer1NonAsciiAva():
         valid = self.server.sec.verify_signature(decr_text,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-                                                 node_id=resp.assertion[0].id,
-                                                 id_attr="")
+                                                 node_id=resp.assertion[0].id)
 
         assert valid
 
@@ -1766,8 +1751,7 @@ class TestServer1NonAsciiAva():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
 
         decr_text = self.server.sec.decrypt(signed_resp, self.client.config.encryption_keypairs[1]["key_file"])
@@ -1779,8 +1763,7 @@ class TestServer1NonAsciiAva():
         valid = self.server.sec.verify_signature(decr_text,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-                                                 node_id=resp.assertion[0].id,
-                                                 id_attr="")
+                                                 node_id=resp.assertion[0].id)
 
         assert valid
 
@@ -1799,8 +1782,7 @@ class TestServer1NonAsciiAva():
         #valid = self.server.sec.verify_signature(decr_text,
         #                                         self.server.config.cert_file,
         #                                         node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-        #                                         node_id=assertion[0].id,
-        #                                         id_attr="")
+        #                                         node_id=assertion[0].id)
         assert valid
 
     def test_encrypted_response_1(self):

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -2679,9 +2679,6 @@ class TestClientNonAsciiAva:
         # Begin with the IdPs side
         _sec = self.server.sec
 
-        nameid_policy = samlp.NameIDPolicy(allow_create="false",
-                                           format=saml.NAMEID_FORMAT_PERSISTENT)
-
         asser_1 = Assertion({"givenName": "Dave"})
 
         farg = add_path(

--- a/tests/test_52_default_sign_alg.py
+++ b/tests/test_52_default_sign_alg.py
@@ -117,16 +117,14 @@ class TestSignedResponse():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
         assert ds.SIG_RSA_SHA512 in str(sresponse.assertion[0]), "Not correctly signed!"
         assert ds.DIGEST_SHA512 in str(sresponse.assertion[0]), "Not correctly signed!"
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-                                                 node_id=sresponse.assertion[0].id,
-                                                 id_attr="")
+                                                 node_id=sresponse.assertion[0].id)
         assert valid
 
         self.verify_assertion(sresponse.assertion)
@@ -151,16 +149,14 @@ class TestSignedResponse():
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:protocol:Response',
-                                                 node_id=sresponse.id,
-                                                 id_attr="")
+                                                 node_id=sresponse.id)
         assert valid
         assert ds.SIG_RSA_SHA256 in str(sresponse.assertion[0]), "Not correctly signed!"
         assert ds.DIGEST_SHA256 in str(sresponse.assertion[0]), "Not correctly signed!"
         valid = self.server.sec.verify_signature(signed_resp,
                                                  self.server.config.cert_file,
                                                  node_name='urn:oasis:names:tc:SAML:2.0:assertion:Assertion',
-                                                 node_id=sresponse.assertion[0].id,
-                                                 id_attr="")
+                                                 node_id=sresponse.assertion[0].id)
         assert valid
 
         self.verify_assertion(sresponse.assertion)


### PR DESCRIPTION
### Problem

We need to know _the name of the attribute_ that represents the identifier of the node
that is being signed, or encrypted, or verified. We guess the name -by trying `ID`, `Id`
and `id`- and pass it to `xmlsec1` using the `--id-attr` command line option.

### Analysis

_Why is this needed?_ Shouldn't the attribute names be specified by the corresponding
specifications? Let's look into the specs to find out.

* saml-core:
  * `StatusResponseType` uses `ID`
  * `RequestAbstractType` uses `ID`
  * `Assertion` uses `ID`

* xmldsig-core:
  * `SignatureType` uses `Id`

* xmlenc-core:
  * `EncryptedType` uses `Id`

So, the answer is _yes_ - the attribute names are defined and, instead of guessing, we
should be passing in the id-attribute names as defined by the specs.

_Note_: But, do we even need to do this? If the names are standardized, why do we bother
with this? In fact, the manual for `xmlsec1` explicitly says that

    --id-attr[:<attr-name>] [<node-namespace-uri>:]<node-name>

        adds attributes <attr-name> (default value "id") from all nodes
        with<node-name> and namespace <node-namespace-uri> to the list of
        known ID attributes; this is a hack and  if you can use DTD or schema
        to declare ID attributes instead (see "--dtd-file" option), I don't
        know what else might be broken in your application when you use this
        hack

However, it seems that `xmlsec1` by default will only look for an attribute with name
`id`. The right way to solve this is to pass in a DTD file. Then, `xmlsec1` will
understand that it needs to look up a different attribute name. Unfortunately, there are
no official DTDs (or even unofficial, to my knowledge) for SAML. The SAML specifications
instead provide XSD files. Even though `xmlsec1` mentions _schema_, there doesn't seem
to be a way to pass in an XSD file. So, we have to resort to this "hack".

### Which attribute name when

When we sign a document, we need to point to the node that will be signed. The nodes
that we are signing are always SAML nodes (Assertion, StatusResponseType (Response,
etc), RequestAbstractType (AuthnRequest, etc)). All SAML nodes that will be signed use
`ID` as the attribute name. So, in order to sign and verify a signature, we need to pass
in `ID`.

When encrypting a document, we need to point to the node whose content will be
encrypted. Currently, we use XPath to point to that node, without the use of an id. But,
we could be using an identifier to locate the node, and if we did so, we would still be
using `ID`.

When decrypting a document, we need to point to the node that contains the encrypted
data. This is where things change. Since the SAML node itself is encrypted we cannot
point to an `ID` attribute, as we did in the other cases. Instead, it is specified that
a node named `EncryptedData` exists, that may have an `Id` attribute. This is where we
want to point to. So, we need to use `Id`.

Signed-off-by: Ivan Kanakarakis <ivan.kanak@gmail.com>


### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?