### PR TITLE
Using `os.linesep` to write pem files in a cross-platform way

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -450,7 +450,7 @@ def extract_rsa_key_from_x509_cert(pem):
 
 
 def pem_format(key):
-    return '\n'.join([
+    return os.linesep.join([
         '-----BEGIN CERTIFICATE-----',
         key,
         '-----END CERTIFICATE-----'


### PR DESCRIPTION
In the latest release (5.0.0), PEM certificate files are being written without a proper line break on Windows:

```
-----BEGIN CERTIFICATE-----ew9238rq12 ...
-----END CERTIFICATE-----
```

This PR uses `os.linesep` to write the proper line break characters in the file.

