### PR TITLE
Fixing temporary file creation for Windows

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -9,6 +9,7 @@ import itertools
 import logging
 import os
 import six
+import sys
 
 from time import mktime
 
@@ -17,7 +18,8 @@ from six.moves.urllib import parse
 import saml2.cryptography.asymmetric
 import saml2.cryptography.pki
 
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, gettempdir
+from uuid import uuid4
 from subprocess import Popen
 from subprocess import PIPE
 
@@ -341,10 +343,19 @@ def make_temp(content, suffix="", decode=True, delete_tmpfiles=True):
         content.encode("utf-8") if not isinstance(content, six.binary_type) else content
     )
     content_raw = base64.b64decode(content_encoded) if decode else content_encoded
-    ntf = NamedTemporaryFile(suffix=suffix, delete=delete_tmpfiles)
+    ntf = _make_temp(suffix=suffix, delete_tmpfiles=delete_tmpfiles)
     ntf.write(content_raw)
     ntf.seek(0)
     return ntf
+
+
+def _make_temp(suffix="", delete_tmpfiles=True):
+    # `NamedTemporaryFile` is not very reliable on Windows, so we'll make a
+    # tempfile a different way.
+    if sys.platform == 'win32':
+        return open(os.path.join(gettempdir(), '%s.%s' % (uuid4(), suffix)), 'w+b')
+    else:
+        return NamedTemporaryFile(suffix=suffix, delete=delete_tmpfiles)
 
 
 def split_len(seq, length):
@@ -888,7 +899,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
             key-value parameters
         :result: Whatever xmlsec wrote to an --output temporary file
         """
-        with NamedTemporaryFile(suffix='.xml') as ntf:
+        with _make_temp(suffix='.xml') as ntf:
             com_list.extend(['--output', ntf.name])
             com_list += extra_args
 


### PR DESCRIPTION
We were having issues with the temporary files created by this library on Windows not being readable by the `xmlsec` process. I don't totally understand the problem, but it seems like IIS was retaining some kind of lock on the created files, so the `xmlsec` process couldn't open them for reading. This resulted in 2 different errors:

- First, `xmlsec --verify` failed because it could not read the temporary PEM file that was created for the operation
- After that was fixed, the `xmlsec --verify` hung indefinitely because it could not access the file created for `--output` to go into.

I also see that `NamedTemporaryFile` has some odd behavior on Windows as noted in the Python documentation: https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile

This PR changes the way tempfiles are written on Windows. It still writes them to the temp directory as determined by `tempfile.gettempdir()`, but just uses regular `open` instead of `NamedTemporaryFile`. `uuid4()` is used to generate a unique-ish filename. This fix seems to work well on our Windows server and locally on Windows machines. I'm not sure if this is the best way to do it though---open to other implementations if you don't like this one.

Thanks!



