### PR TITLE
Document default value for 'want_response_signed'

### DIFF
--- a/docs/howto/config.rst
+++ b/docs/howto/config.rst
@@ -498,6 +498,8 @@ want_response_signed
 Indicates that Authentication Responses to this SP must be signed. If set to
 True, the SP will not consume any SAML Responses that are not signed.
 
+Valid values are True or False. Default value is True.
+
 Example::
 
     "service": {


### PR DESCRIPTION
Document the default value for 'want_response_signed' so users don't have to dig through the code to fine it.

### All Submissions:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



