### PR TITLE
Disco URL can already contain parameters

### DIFF
--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -925,7 +925,11 @@ class Base(Entity):
         }
 
         params = urlencode({k: v for k, v in args.items() if v})
-        return "%s?%s" % (url, params)
+        # url can already contain some parameters
+        if '?' in url:
+            return "%s&%s" % (url, params)
+        else:
+            return "%s?%s" % (url, params)
 
     @staticmethod
     def parse_discovery_service_response(url="", query="",


### PR DESCRIPTION
If disco url already contains parameters we need to add return_url as another parametr into the URL.

Current problem is that return_url parameter is added using fixed '?' into the URL. If the disco URL already contained a parameter, the DS services will fail if it receives URL with double '?'. The change just search the url for '?', if it is there then return_url is added as additional URL parameter using '&'.



