### PR TITLE
Fix eidas attribute mapping for legal person

### DIFF
--- a/src/saml2/attributemaps/saml_uri.py
+++ b/src/saml2/attributemaps/saml_uri.py
@@ -36,9 +36,9 @@ MAP = {
     'identifier': 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
     'fro': {
         EIDAS_LEGALPERSON+'LegalPersonIdentifier': 'LegalPersonIdentifier',
-        EIDAS_LEGALPERSON+'LegalAddress': 'LegalAddress',
+        EIDAS_LEGALPERSON+'LegalPersonAddress': 'LegalAddress',
         EIDAS_LEGALPERSON+'LegalName': 'LegalName',
-        EIDAS_LEGALPERSON+'VATRegistration': 'VATRegistration',
+        EIDAS_LEGALPERSON+'VATRegistrationNumber': 'VATRegistration',
         EIDAS_LEGALPERSON+'TaxReference': 'TaxReference',
         EIDAS_LEGALPERSON+'BusinessCodes': 'BusinessCodes',
         EIDAS_LEGALPERSON+'LEI': 'LEI',
@@ -218,9 +218,9 @@ MAP = {
     },
     'to': {
         'LegalPersonIdentifier': EIDAS_LEGALPERSON+'LegalPersonIdentifier',
-        'LegalAddress': EIDAS_LEGALPERSON+'LegalAddress',
+        'LegalAddress': EIDAS_LEGALPERSON+'LegalPersonAddress',
         'LegalName': EIDAS_LEGALPERSON+'LegalName',
-        'VATRegistration': EIDAS_LEGALPERSON+'VATRegistration',
+        'VATRegistration': EIDAS_LEGALPERSON+'VATRegistrationNumber',
         'TaxReference': EIDAS_LEGALPERSON+'TaxReference',
         'BusinessCodes': EIDAS_LEGALPERSON+'BusinessCodes',
         'LEI': EIDAS_LEGALPERSON+'LEI',


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


According to https://ec.europa.eu/cefdigital/wiki/download/attachments/82773108/eIDAS%20SAML%20Attribute%20Profile%20v1.2%20Final.pdf?version=2&modificationDate=1571068651772&api=v2 the correct name for `VATRegistration` is `http://eidas.europa.eu/attributes/legalperson/VATRegistrationNumber` and for `LegalAddress` is `http://eidas.europa.eu/attributes/legalperson/LegalPersonAddress`
