### PR TITLE
fix escape not in cgi in example for newer pythons

### DIFF
--- a/example/sp-wsgi/sp.py
+++ b/example/sp-wsgi/sp.py
@@ -2,7 +2,10 @@
 from __future__ import print_function
 
 import argparse
-import cgi
+try:
+    import html
+except:
+    import cgi as html
 import importlib
 import logging
 import os
@@ -47,6 +50,9 @@ from saml2.s_utils import rndstr
 from saml2.s_utils import sid
 from saml2.saml import NAMEID_FORMAT_PERSISTENT
 from saml2.samlp import Extensions
+
+def _html_escape(payload):
+    return html.escape(payload, quote=True)
 
 logger = logging.getLogger("")
 hdlr = logging.FileHandler("spx.log")
@@ -699,7 +705,7 @@ def main(environ, start_response, sp):
     body = dict_to_table(user.data)
     body.append(
         "<br><pre>{authn_stmt}</pre>".format(
-            authn_stmt=cgi.escape(user.authn_statement)
+            authn_stmt=_html_escape(user.authn_statement)
         )
     )
     body.append("<br><a href='/logout'>logout</a>")


### PR DESCRIPTION
### Issue

`module 'cgi' has no attribute 'escape'`-error when running the example

#### Steps to reproduce

- use Python 3.8.*
- in example folder run `./all.sh start`
- open http://localhost:8087/
- enter credentials (roland)
- The above error is shown in the browser and in console

#### Expected result

No error but an AuthnStatement should be shown in the browser.

### Fix 

I fixed this to be consistent with the fix in https://github.com/IdentityPython/pysaml2/pull/610.
No functionality is changed. 
This just fixes the example for newer Python versions.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
  * no change in functionality, no tests required.
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



