### PR TITLE
Fix pylint errors

### DIFF
--- a/src/saml2/__init__.py
+++ b/src/saml2/__init__.py
@@ -40,8 +40,7 @@ except ImportError:
 import defusedxml.ElementTree
 
 
-root_logger = logging.getLogger(__name__)
-root_logger.level = logging.NOTSET
+logger = logging.getLogger(__name__)
 
 NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:assertion'
 # TEMPLATE = '{urn:oasis:names:tc:SAML:2.0:assertion}%s'

--- a/src/saml2/authn.py
+++ b/src/saml2/authn.py
@@ -29,13 +29,13 @@ class UserAuthnMethod(object):
         self.srv = srv
 
     def __call__(self, *args, **kwargs):
-        raise NotImplemented
+        raise NotImplementedError
 
     def authenticated_as(self, **kwargs):
-        raise NotImplemented
+        raise NotImplementedError
 
     def verify(self, **kwargs):
-        raise NotImplemented
+        raise NotImplementedError
 
 
 def is_equal(a, b):

--- a/src/saml2/client.py
+++ b/src/saml2/client.py
@@ -222,7 +222,7 @@ class Saml2Client(Base):
                     sign = True
 
                 if sign is None:
-                    sign = self.logout_requests_signed
+                    sign = self.config.logout_requests_signed
 
                 sigalg = None
                 if sign:

--- a/src/saml2/cryptography/symmetric.py
+++ b/src/saml2/cryptography/symmetric.py
@@ -89,7 +89,7 @@ class Fernet(object):
             "The 'Fernet' class does not need a build_cipher method."
             "Remove any calls to this method. "
             "In the next version, this method will be removed."
-        ).format(name=cls.__name__, type=type(cls).__name__)
+        )
         _warnings.warn(_deprecation_msg, DeprecationWarning)
 
 

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -159,7 +159,6 @@ class Entity(HTTPBase):
                 vo.sp = self
 
         self.metadata = self.config.metadata
-        self.config.setup_logger()
         self.debug = self.config.debug
 
         self.sec = security_context(self.config)

--- a/src/saml2/httpbase.py
+++ b/src/saml2/httpbase.py
@@ -84,9 +84,10 @@ def _since_epoch(cdate):
             break
 
     if t == -1:
-        raise (Exception,
-               'ValueError: Date "{0}" does not match any of: {1}'.format(
-                   cdate,TIME_FORMAT))
+        err = 'ValueError: Date "{0}" does not match any of: {1}'.format(
+            cdate, TIME_FORMAT
+        )
+        raise Exception(err)
 
     return calendar.timegm(t)
 

--- a/src/saml2/httpbase.py
+++ b/src/saml2/httpbase.py
@@ -329,7 +329,7 @@ class HTTPBase(object):
                 "url": "%s?%s" % (destination, query)
             }
         else:
-            raise NotImplemented
+            raise NotImplementedError
 
         return info
 

--- a/src/saml2/ident.py
+++ b/src/saml2/ident.py
@@ -140,7 +140,7 @@ class IdentDB(object):
         del self.db[name_id.text]
 
     def remove_local(self, sid):
-        if isinstance(sid, unicode):
+        if not isinstance(sid, bytes):
             sid = sid.encode("utf-8")
 
         try:

--- a/src/saml2/mongo_store.py
+++ b/src/saml2/mongo_store.py
@@ -321,7 +321,7 @@ class EptidMDB(Eptid):
             raise CorruptDatabase("Found more than one EPTID document")
 
     def __setitem__(self, key, value):
-        _ = self.mdb.store(key, **{"eptid": value})
+        self.mdb.store(key, **{"eptid": value})
 
 
 #------------------------------------------------------------------------------

--- a/src/saml2/s2repoze/plugins/formswithhidden.py
+++ b/src/saml2/s2repoze/plugins/formswithhidden.py
@@ -1,4 +1,4 @@
-import urllib
+from six.moves.urllib.parse import urlencode
 
 from paste.httpheaders import CONTENT_LENGTH
 from paste.httpheaders import CONTENT_TYPE
@@ -71,7 +71,7 @@ class FormHiddenPlugin(FormPlugin):
                 return None
             del query[self.login_form_qs]
             query.update(qinfo)
-            environ["QUERY_STRING"] = urllib.urlencode(query)
+            environ["QUERY_STRING"] = urlencode(query)
             environ["repoze.who.application"] = HTTPFound(construct_url(environ))
             credentials = {"login": login, "password": password}
             max_age = form.get("max_age", None)

--- a/src/saml2/s_utils.py
+++ b/src/saml2/s_utils.py
@@ -379,10 +379,7 @@ def signature(secret, parts):
             part = part.encode('utf-8')
         newparts.append(part)
     parts = newparts
-    if sys.version_info >= (2, 5):
-        csum = hmac.new(secret, digestmod=hashlib.sha1)
-    else:
-        csum = hmac.new(secret, digestmod=sha)
+    csum = hmac.new(secret, digestmod=hashlib.sha1)
 
     for part in parts:
         csum.update(part)

--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -160,17 +160,16 @@ class AttributeValueBase(SamlBase):
 
     def set_text(self, value, base64encode=False):
         def _wrong_type_value(xsd, value):
-            msg = _str('Type and value do not match: {xsd}:{type}:{value}')
+            msg = 'Type and value do not match: {xsd}:{type}:{value}'
             msg = msg.format(xsd=xsd, type=type(value), value=value)
             raise ValueError(msg)
 
         # only work with six.string_types
-        _str = unicode if six.PY2 else str
         if isinstance(value, six.binary_type):
             value = value.decode('utf-8')
 
         type_to_xsd = {
-            _str:       'string',
+            str:        'string',
             int:        'integer',
             float:      'float',
             bool:       'boolean',
@@ -183,51 +182,51 @@ class AttributeValueBase(SamlBase):
         # - a function to turn that type into a text-value
         xsd_types_props = {
             'string': {
-                'type': _str,
-                'to_type': _str,
-                'to_text': _str,
+                'type': str,
+                'to_type': str,
+                'to_text': str,
             },
             'integer': {
                 'type': int,
                 'to_type': int,
-                'to_text': _str,
+                'to_text': str,
             },
             'short': {
                 'type': int,
                 'to_type': int,
-                'to_text': _str,
+                'to_text': str,
             },
             'int': {
                 'type': int,
                 'to_type': int,
-                'to_text': _str,
+                'to_text': str,
             },
             'long': {
                 'type': int,
                 'to_type': int,
-                'to_text': _str,
+                'to_text': str,
             },
             'float': {
                 'type': float,
                 'to_type': float,
-                'to_text': _str,
+                'to_text': str,
             },
             'double': {
                 'type': float,
                 'to_type': float,
-                'to_text': _str,
+                'to_text': str,
             },
             'boolean': {
                 'type': bool,
                 'to_type': lambda x: {
                     'true': True,
                     'false': False,
-                }[_str(x).lower()],
-                'to_text': lambda x: _str(x).lower(),
+                }[str(x).lower()],
+                'to_text': lambda x: str(x).lower(),
             },
             'base64Binary': {
-                'type': _str,
-                'to_type': _str,
+                'type': str,
+                'to_type': str,
                 'to_text': (
                     lambda x: base64.encodebytes(x.encode()) if base64encode else x
                 ),
@@ -264,7 +263,7 @@ class AttributeValueBase(SamlBase):
         to_text = xsd_type_props.get('to_text', str)
 
         # cast to correct type before type-checking
-        if type(value) is _str and valid_type is not _str:
+        if type(value) is str and valid_type is not str:
             try:
                 value = to_type(value)
             except (TypeError, ValueError, KeyError) as e:

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -734,18 +734,14 @@ class CryptoBackendXmlSec1(CryptoBackend):
         :param key_type: The type of session key to use.
         :return: The encrypted text
         """
-        if six.PY2:
-            _str = unicode
-        else:
-            _str = str
 
         if isinstance(statement, SamlBase):
             statement = pre_encrypt_assertion(statement)
 
-        tmp = make_temp(_str(statement),
+        tmp = make_temp(str(statement),
                         decode=False,
                         delete_tmpfiles=self.delete_tmpfiles)
-        tmp2 = make_temp(_str(template),
+        tmp2 = make_temp(str(template),
                          decode=False,
                          delete_tmpfiles=self.delete_tmpfiles)
 

--- a/src/saml2/validate.py
+++ b/src/saml2/validate.py
@@ -80,7 +80,7 @@ def valid_date_time(item):
 
 def valid_url(url):
     try:
-        _ = urlparse.urlparse(url)
+        _ = urlparse(url)
     except Exception:
         raise NotValid("URL")
 

--- a/tests/test_31_config.py
+++ b/tests/test_31_config.py
@@ -8,7 +8,7 @@ from saml2.mdstore import MetadataStore, name
 from saml2 import BINDING_HTTP_REDIRECT, BINDING_SOAP, BINDING_HTTP_POST
 from saml2.config import SPConfig, IdPConfig, Config
 
-from saml2 import root_logger
+from saml2 import logger
 
 from pathutils import dotname, full_path
 from saml2.sigver import security_context, CryptoBackendXMLSecurity
@@ -297,57 +297,12 @@ def test_wayf():
     assert name(ent) == 'Example Co.'
     assert name(ent, "se") == 'Exempel AB'
 
-    c.setup_logger()
-
-    assert root_logger.level != logging.NOTSET
-    assert root_logger.level == logging.INFO
-    assert len(root_logger.handlers) == 1
-    assert isinstance(root_logger.handlers[0],
-                      logging.handlers.RotatingFileHandler)
-    handler = root_logger.handlers[0]
-    assert handler.backupCount == 5
-    try:
-        assert handler.maxBytes == 100000
-    except AssertionError:
-        assert handler.maxBytes == 500000
-    assert handler.mode == "a"
-    assert root_logger.name == "saml2"
-    assert root_logger.level == 20
-
 
 def test_conf_syslog():
     c = SPConfig().load_file("server_conf_syslog")
     c.context = "sp"
 
-    # otherwise the logger setting is not changed
-    root_logger.level = logging.NOTSET
-    while root_logger.handlers:
-        handler = root_logger.handlers[-1]
-        root_logger.removeHandler(handler)
-        handler.flush()
-        handler.close()
 
-    print(c.logger)
-    c.setup_logger()
-
-    assert root_logger.level != logging.NOTSET
-    assert root_logger.level == logging.INFO
-    assert len(root_logger.handlers) == 1
-    assert isinstance(root_logger.handlers[0],
-                      logging.handlers.SysLogHandler)
-    handler = root_logger.handlers[0]
-    print(handler.__dict__)
-    assert handler.facility == "local3"
-    assert handler.address == ('localhost', 514)
-    if ((sys.version_info.major == 2 and sys.version_info.minor >= 7) or
-        sys.version_info.major > 2):
-        assert handler.socktype == 2
-    else:
-        pass
-    assert root_logger.name == "saml2"
-    assert root_logger.level == 20
-
-#noinspection PyUnresolvedReferences
 def test_3():
     cnf = Config()
     cnf.load_file(dotname("sp_1_conf"))


### PR DESCRIPTION
Running `pylint-3.8 -E src/` to scan for errors with `pylint` lots of errors are reported. There are some false positives in there caused by mix-in classes but still there are many symbols found which are not available in PY3 anymore.

Not all of them are actual errors. Some have to do with the way the library was written, some with optional dependencies, some with python2 code. There was never a migration from python2; pysaml2 supported both python versions until some point in time when we decided we should not give attention to python2 compatibility. As the library evolves python2 compatibility checks will be removed and hopefully the code will become cleaner.

After the fixes, reported errors should be either import-errors of optional dependencies or invocation of methods and lookup of object attributes that belong to subclasses. These should be fixed but require a bigger refactor on the codebase.

Based off of #675 

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?