### PR TITLE
Set requested attributes per authn request

### DIFF
--- a/src/saml2/attribute_converter.py
+++ b/src/saml2/attribute_converter.py
@@ -62,7 +62,7 @@ def ac_factory(path=""):
         if path not in sys.path:
             sys.path.insert(0, path)
 
-        for fil in os.listdir(path):
+        for fil in sorted(os.listdir(path)):
             if fil.endswith(".py"):
                 mod = import_module(fil[:-3])
                 for key, item in mod.__dict__.items():

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -402,7 +402,9 @@ class Base(Entity):
             if not name and not friendly_name:
                 raise ValueError(
                     "Missing required attribute: '{}' or '{}'".format(
-                        'name', 'friendly_name'))
+                        'name', 'friendly_name'
+                    )
+                )
 
             if not name:
                 for converter in self.config.attribute_converters:
@@ -426,14 +428,16 @@ class Base(Entity):
                             name_format = converter.name_format
                         break
 
-            items.append(RequestedAttribute(
-                is_required=is_required,
-                name_format=name_format,
-                friendly_name=friendly_name,
-                name=name))
+            items.append(
+                RequestedAttribute(
+                    is_required=is_required,
+                    name_format=name_format,
+                    friendly_name=friendly_name,
+                    name=name,
+                )
+            )
 
-        item = RequestedAttributes(
-            extension_elements=items)
+        item = RequestedAttributes(extension_elements=items)
         extensions.add_extension_element(item)
 
         force_authn = str(
@@ -454,8 +458,7 @@ class Base(Entity):
         if sign is None:
             sign = self.authn_requests_signed
 
-        if (sign and self.sec.cert_handler.generate_cert()) or \
-                        client_crt is not None:
+        if (sign and self.sec.cert_handler.generate_cert()) or client_crt is not None:
             with self.lock:
                 self.sec.cert_handler.update_cert(True, client_crt)
                 if client_crt is not None:

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -252,9 +252,11 @@ class Base(Entity):
         :param allow_create: If the identity provider is allowed, in the course
             of fulfilling the request, to create a new identifier to represent
             the principal.
-        :param requested_attributes: A list of dicts which contain attributes
-            to be appended to the requested_attributes config option. The
-            dicts format is similar to the requested_attributes config option.
+        :param requested_attributes: A list of dicts which define attributes to
+            be used as eIDAS Requested Attributes for this request. If not
+            defined the configuration option requested_attributes will be used,
+            if defined. The format is the same as the requested_attributes
+            configuration option.
         :param kwargs: Extra key word arguments
         :return: either a tuple of request ID and <samlp:AuthnRequest> instance
                  or a tuple of request ID and str when sign is set to True

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -381,60 +381,58 @@ class Base(Entity):
             item = sp_type.SPType(text=conf_sp_type)
             extensions.add_extension_element(item)
 
-        if requested_attributes:
-            requested_attributes += \
-                self.config.getattr('requested_attributes', 'sp')
-        else:
-            requested_attributes = \
-                self.config.getattr('requested_attributes', 'sp')
+        requested_attrs = (
+            requested_attributes
+            or self.config.getattr('requested_attributes', 'sp')
+            or []
+        )
 
-        if requested_attributes:
-            if not extensions:
-                extensions = Extensions()
+        if not extensions:
+            extensions = Extensions()
 
-            items = []
-            for attr in requested_attributes:
-                friendly_name = attr.get('friendly_name')
-                name = attr.get('name')
-                name_format = attr.get('name_format')
-                is_required = str(attr.get('required', False)).lower()
+        items = []
+        for attr in requested_attrs:
+            friendly_name = attr.get('friendly_name')
+            name = attr.get('name')
+            name_format = attr.get('name_format')
+            is_required = str(attr.get('required', False)).lower()
 
-                if not name and not friendly_name:
-                    raise ValueError(
-                        "Missing required attribute: '{}' or '{}'".format(
-                            'name', 'friendly_name'))
+            if not name and not friendly_name:
+                raise ValueError(
+                    "Missing required attribute: '{}' or '{}'".format(
+                        'name', 'friendly_name'))
 
-                if not name:
-                    for converter in self.config.attribute_converters:
-                        try:
-                            name = converter._to[friendly_name.lower()]
-                        except KeyError:
-                            continue
-                        else:
-                            if not name_format:
-                                name_format = converter.name_format
-                            break
+            if not name:
+                for converter in self.config.attribute_converters:
+                    try:
+                        name = converter._to[friendly_name.lower()]
+                    except KeyError:
+                        continue
+                    else:
+                        if not name_format:
+                            name_format = converter.name_format
+                        break
 
-                if not friendly_name:
-                    for converter in self.config.attribute_converters:
-                        try:
-                            friendly_name = converter._fro[name.lower()]
-                        except KeyError:
-                            continue
-                        else:
-                            if not name_format:
-                                name_format = converter.name_format
-                            break
+            if not friendly_name:
+                for converter in self.config.attribute_converters:
+                    try:
+                        friendly_name = converter._fro[name.lower()]
+                    except KeyError:
+                        continue
+                    else:
+                        if not name_format:
+                            name_format = converter.name_format
+                        break
 
-                items.append(RequestedAttribute(
-                    is_required=is_required,
-                    name_format=name_format,
-                    friendly_name=friendly_name,
-                    name=name))
+            items.append(RequestedAttribute(
+                is_required=is_required,
+                name_format=name_format,
+                friendly_name=friendly_name,
+                name=name))
 
-            item = RequestedAttributes(
-                extension_elements=items)
-            extensions.add_extension_element(item)
+        item = RequestedAttributes(
+            extension_elements=items)
+        extensions.add_extension_element(item)
 
         force_authn = str(
             kwargs.pop("force_authn", None)

--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -509,50 +509,6 @@ class SPConfig(Config):
 
         return None
 
-    def load(self, cnf, metadata_construction=False):
-        super().load(cnf, metadata_construction=False)
-        self.fix_requested_attributes()
-        return self
-
-    def fix_requested_attributes(self):
-        """Add friendly_name or name if missing to the requested attributes"""
-        requested_attrs = self.getattr('requested_attributes', 'sp')
-
-        if not requested_attrs:
-            return
-
-        for attr in requested_attrs:
-            friendly_name = attr.get('friendly_name')
-            name = attr.get('name')
-            name_format = attr.get('name_format')
-
-            if not name and not friendly_name:
-                raise ValueError(
-                    "Missing required attribute: '{}' or '{}'".format(
-                        'name', 'friendly_name'))
-
-            if not name:
-                for converter in self.attribute_converters:
-                    try:
-                        attr['name'] = converter._to[friendly_name.lower()]
-                    except KeyError:
-                        continue
-                    else:
-                        if not name_format:
-                            attr['name_format'] = converter.name_format
-                        break
-
-            if not friendly_name:
-                for converter in self.attribute_converters:
-                    try:
-                        attr['friendly_name'] = converter._fro[name.lower()]
-                    except KeyError:
-                        continue
-                    else:
-                        if not name_format:
-                            attr['name_format'] = converter.name_format
-                        break
-
 
 class IdPConfig(Config):
     def_context = "idp"

--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -509,6 +509,50 @@ class SPConfig(Config):
 
         return None
 
+    def load(self, cnf, metadata_construction=False):
+        super().load(cnf, metadata_construction=False)
+        self.fix_requested_attributes()
+        return self
+
+    def fix_requested_attributes(self):
+        """Add friendly_name or name if missing to the requested attributes"""
+        requested_attrs = self.getattr('requested_attributes', 'sp')
+
+        if not requested_attrs:
+            return
+
+        for attr in requested_attrs:
+            friendly_name = attr.get('friendly_name')
+            name = attr.get('name')
+            name_format = attr.get('name_format')
+
+            if not name and not friendly_name:
+                raise ValueError(
+                    "Missing required attribute: '{}' or '{}'".format(
+                        'name', 'friendly_name'))
+
+            if not name:
+                for converter in self.attribute_converters:
+                    try:
+                        attr['name'] = converter._to[friendly_name.lower()]
+                    except KeyError:
+                        continue
+                    else:
+                        if not name_format:
+                            attr['name_format'] = converter.name_format
+                        break
+
+            if not friendly_name:
+                for converter in self.attribute_converters:
+                    try:
+                        attr['friendly_name'] = converter._fro[name.lower()]
+                    except KeyError:
+                        continue
+                    else:
+                        if not name_format:
+                            attr['name_format'] = converter.name_format
+                        break
+
 
 class IdPConfig(Config):
     def_context = "idp"

--- a/tests/server_conf.py
+++ b/tests/server_conf.py
@@ -16,15 +16,15 @@ CONFIG = {
             "idp": ["urn:mace:example.com:saml:roland:idp"],
             "requested_attributes": [
                 {
-                    "name": "http://eidas.europa.eu/attributes/naturalperson/DateOfBirth",
+                    "name": "urn:oid:1.3.6.1.4.1.5923.1.1.1.2",
                     "required": False,
                 },
                 {
-                    "friendly_name": "PersonIdentifier",
+                    "friendly_name": "eduPersonNickname",
                     "required": True,
                 },
                 {
-                    "friendly_name": "PlaceOfBirth",
+                    "friendly_name": "eduPersonScopedAffiliation",
                 },
             ],
         }

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -288,39 +288,32 @@ class TestClient:
 
     def test_create_auth_request_requested_attributes(self):
         req_attr = [{"friendly_name": "eduPersonOrgUnitDN", "required": True}]
-        ar_str = "%s" % self.client.create_authn_request(
+        ar_id, ar = self.client.create_authn_request(
             "http://www.example.com/sso",
             message_id="id1",
             requested_attributes=req_attr
-        )[1]
-
-        ar = samlp.authn_request_from_string(ar_str)
-
-        node_requested_attributes = None
-        for e in ar.extensions.extension_elements:
-            if e.tag == RequestedAttributes.c_tag:
-                node_requested_attributes = e
-                break
-        assert node_requested_attributes is not None
-
-        attr = None
-        for c in node_requested_attributes.children:
-            if c.attributes['FriendlyName'] == "eduPersonOrgUnitDN":
-                attr = c
-                break
-
-        assert attr
-        assert attr.tag == RequestedAttribute.c_tag
-        assert attr.attributes['isRequired'] == 'true'
-        assert (
-            attr.attributes['Name']
-            == 'urn:mace:dir:attribute-def:eduPersonOrgUnitDN'
         )
-        assert attr.attributes['FriendlyName'] == 'eduPersonOrgUnitDN'
-        assert (
-            attr.attributes['NameFormat']
-            == 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic'
+
+        req_attrs_nodes = (
+            e
+            for e in ar.extensions.extension_elements
+            if e.tag == RequestedAttributes.c_tag
         )
+        req_attrs_node = next(req_attrs_nodes, None)
+        assert req_attrs_node is not None
+
+        attrs = (
+            child
+            for child in req_attrs_node.children
+            if child.friendly_name == "eduPersonOrgUnitDN"
+        )
+        attr = next(attrs, None)
+        assert attr is not None
+        assert attr.c_tag == RequestedAttribute.c_tag
+        assert attr.is_required == 'true'
+        assert attr.name == 'urn:mace:dir:attribute-def:eduPersonOrgUnitDN'
+        assert attr.friendly_name == 'eduPersonOrgUnitDN'
+        assert attr.name_format == 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic'
 
     def test_create_auth_request_unset_force_authn_by_default(self):
         req_id, req = self.client.create_authn_request(


### PR DESCRIPTION
Add requested_attributes param to create_authn_request.

This will allow us to add different requested attributes on each request.

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?