### PR TITLE
MDQ http request ssl validation as paramenter

### DIFF
--- a/src/saml2/request.py
+++ b/src/saml2/request.py
@@ -44,6 +44,7 @@ class Request(object):
         # own copy
         self.xmlstr = xmldata[:]
         logger.debug("xmlstr: %s", self.xmlstr)
+
         try:
             self.message = self.signature_check(xmldata, origdoc=origdoc,
                                                 must=must,
@@ -51,7 +52,7 @@ class Request(object):
         except TypeError:
             raise
         except Exception as excp:
-            logger.info("EXCEPTION: %s", excp)
+            logger.error("EXCEPTION: %s", excp)
 
         if not self.message:
             logger.error("Response was not correctly signed")


### PR DESCRIPTION
This PR enable ad additional option for Metadata loader and avoid http requests ssl certificate validation.
This is not intented for production environment, it's only useful for testing environment. 
Configuration example here:

````
'metadata': {
        "remote": [{
            "url": 'https://satosa.testunical.it/Saml2/metadata',
            "disable_ssl_certificate_validation": True,
             }],

        "mdq": [{
            "url": "http://localhost:8001",
            "disable_ssl_certificate_validation": True,
            }]
},

````

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



