### PR TITLE
Fixes #693: Allow generation of signed metadata in python3

### DIFF
--- a/src/saml2/metadata.py
+++ b/src/saml2/metadata.py
@@ -66,10 +66,10 @@ def metadata_tostring_fix(desc, nspair, xmlstring=""):
     if not xmlstring:
         xmlstring = desc.to_string(nspair)
 
-    if six.PY2:
+    try:
         if "\"xs:string\"" in xmlstring and XMLNSXS not in xmlstring:
             xmlstring = xmlstring.replace(MDNS, MDNS + XMLNSXS)
-    else:
+    except TypeError:
         if b"\"xs:string\"" in xmlstring and bXMLNSXS not in xmlstring:
             xmlstring = xmlstring.replace(bMDNS, bMDNS + bXMLNSXS)
 

--- a/tests/test_39_metadata.py
+++ b/tests/test_39_metadata.py
@@ -1,7 +1,10 @@
 import copy
 from saml2.config import SPConfig
-from saml2.metadata import entity_descriptor
+from saml2.metadata import create_metadata_string, entity_descriptor
 from saml2.saml import NAME_FORMAT_URI, NAME_FORMAT_BASIC
+from saml2 import sigver
+
+from pathutils import full_path
 
 __author__ = 'roland'
 
@@ -45,6 +48,18 @@ def test_requested_attribute_name_format():
     assert len(acs.requested_attribute) == 4
     for req_attr in acs.requested_attribute:
         assert req_attr.name_format == NAME_FORMAT_BASIC
+
+
+def test_signed_metadata_proper_str_bytes_handling():
+    sp_conf_2 = sp_conf.copy()
+    sp_conf_2['key_file'] = full_path("test.key")
+    sp_conf_2['cert_file'] = full_path("inc-md-cert.pem")
+    # requires xmlsec binaries per https://pysaml2.readthedocs.io/en/latest/examples/sp.html
+    sp_conf_2['xmlsec_binary'] = sigver.get_xmlsec_binary(["/opt/local/bin"])
+    cnf = SPConfig().load(sp_conf_2, metadata_construction=True)
+
+    # This will raise TypeError if string/bytes handling is not correct
+    sp_metadata = create_metadata_string('', config=cnf, sign=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #693, where it was not possible to generate signed metadata using the `create_metadata_string` function in a python3 environment. 

I'm not sure in what circumstances the `xmlstring` argument will show up as bytes, but to maintain compatibility, I left it. The assumption that python3 environments would use bytes that was previously in the code was wrong, but there may be situations where it does occur, and this would preserve that ability. No significant performance concerns. 

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests? (686 passed, 2 skipped, 35 unrelated warnings)
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?
