### PR TITLE
 Fix automatic inversion of attribute map files

### DIFF
--- a/src/saml2/attribute_converter.py
+++ b/src/saml2/attribute_converter.py
@@ -98,7 +98,9 @@ def _find_maps_in_module(module):
     for key, item in module.__dict__.items():
         if key.startswith("__"):
             continue
-        if isinstance(item, dict) and "to" in item and "fro" in item:
+        if isinstance(item, dict) and "identifier" in item and (
+            "to" in item or "fro" in item
+        ):
             yield item
 
 

--- a/src/saml2/attribute_converter.py
+++ b/src/saml2/attribute_converter.py
@@ -40,11 +40,8 @@ def load_maps(dirspec):
     for fil in os.listdir(dirspec):
         if fil.endswith(".py"):
             mod = import_module(fil[:-3])
-            for key, item in mod.__dict__.items():
-                if key.startswith("__"):
-                    continue
-                if isinstance(item, dict) and "to" in item and "fro" in item:
-                    mapd[item["identifier"]] = item
+            for item in _find_maps_in_module(mod):
+                mapd[item["identifier"]] = item
 
     return mapd
 
@@ -54,7 +51,7 @@ def ac_factory(path=""):
 
     :param path: The path to a directory where the attribute maps are expected
         to reside.
-    :return: A AttributeConverter instance
+    :return: A list of AttributeConverter instances
     """
     acs = []
 
@@ -65,28 +62,44 @@ def ac_factory(path=""):
         for fil in sorted(os.listdir(path)):
             if fil.endswith(".py"):
                 mod = import_module(fil[:-3])
-                for key, item in mod.__dict__.items():
-                    if key.startswith("__"):
-                        continue
-                    if isinstance(item,
-                                  dict) and "to" in item and "fro" in item:
-                        atco = AttributeConverter(item["identifier"])
-                        atco.from_dict(item)
-                        acs.append(atco)
+                acs.extend(_attribute_map_module_to_acs(mod))
     else:
         from saml2 import attributemaps
 
         for typ in attributemaps.__all__:
             mod = import_module(".%s" % typ, "saml2.attributemaps")
-            for key, item in mod.__dict__.items():
-                if key.startswith("__"):
-                    continue
-                if isinstance(item, dict) and "to" in item and "fro" in item:
-                    atco = AttributeConverter(item["identifier"])
-                    atco.from_dict(item)
-                    acs.append(atco)
+            acs.extend(_attribute_map_module_to_acs(mod))
 
     return acs
+
+
+def _attribute_map_module_to_acs(module):
+    """Scan an attribute map module and return any attribute maps defined
+
+    :param: module: the python map module
+    :type: types.ModuleType
+    :return: a generator yielding AttributeConverter defintions
+    :rtype: typing.Iterable[AttributeConverter]
+    """
+    for item in _find_maps_in_module(module):
+        atco = AttributeConverter(item["identifier"])
+        atco.from_dict(item)
+        yield atco
+
+
+def _find_maps_in_module(module):
+    """Find attribute map dictionaries in a map file
+
+    :param: module: the python map module
+    :type: types.ModuleType
+    :return: a generator yielding dict objects which have the right shape
+    :rtype: typing.Iterable[dict]
+    """
+    for key, item in module.__dict__.items():
+        if key.startswith("__"):
+            continue
+        if isinstance(item, dict) and "to" in item and "fro" in item:
+            yield item
 
 
 def to_local(acs, statement, allow_unknown_attributes=False):


### PR DESCRIPTION
https://pysaml2.readthedocs.io/en/latest/howto/config.html#attribute-map-dir says:

> Since _to_ in most cases is the inverse of the _fro_ file, the software allows you only to specify one of them, and it will automatically create the other.

The code to do this inversion exists, but is unreachable, because the code that looks for attribute maps in a python module requires both `to` and `fro` to be defined. This PR modifies the condition for an attribute map dict so that *either* `to` or `fro` must be specified, in addition to `identifier` (which the code assumes exists).

Since there were three copies of this condition, I have first factored out the common code. (This is in a separate commit which makes no functional changes).  [Is `load_maps` used anywhere? I couldn't find any references.]

Sorry I've not added any tests - I couldn't immediately see how this could best be tested.


### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



