### PR TITLE
Fix wrong identifiers for ecdsa algos

### DIFF
--- a/src/saml2/algsupport.py
+++ b/src/saml2/algsupport.py
@@ -25,11 +25,11 @@ SIGNING_METHODS = {
     "rsa-sha512": 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512',
     "dsa-sha1": 'http://www.w3.org/2000/09/xmldsig#dsa-sha1',
     'dsa-sha256': 'http://www.w3.org/2009/xmldsig11#dsa-sha256',
-    'ecdsa_sha1': 'http://www.w3.org/2001/04/xmldsig-more#ECDSA_sha1',
-    'ecdsa_sha224': 'http://www.w3.org/2001/04/xmldsig-more#ECDSA_sha224',
-    'ecdsa_sha256': 'http://www.w3.org/2001/04/xmldsig-more#ECDSA_sha256',
-    'ecdsa_sha384': 'http://www.w3.org/2001/04/xmldsig-more#ECDSA_sha384',
-    'ecdsa_sha512': 'http://www.w3.org/2001/04/xmldsig-more#ECDSA_sha512',
+    'ecdsa-sha1': 'http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1',
+    'ecdsa-sha224': 'http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha224',
+    'ecdsa-sha256': 'http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256',
+    'ecdsa-sha384': 'http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384',
+    'ecdsa-sha512': 'http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512',
 }
 
 

--- a/src/saml2/xmldsig/__init__.py
+++ b/src/saml2/xmldsig/__init__.py
@@ -31,11 +31,11 @@ DIGEST_AVAIL_ALG = DIGEST_ALLOWED_ALG + (('DIGEST_MD5', DIGEST_MD5),)
 
 SIG_DSA_SHA1 = 'http://www.w3.org/2000/09/xmldsig#dsa-sha1'
 SIG_DSA_SHA256 = 'http://www.w3.org/2009/xmldsig11#dsa-sha256'
-SIG_ECDSA_SHA1 = 'http://www.w3.org/2001/04/xmldsig-more#ECDSA_sha1'
-SIG_ECDSA_SHA224 = 'http://www.w3.org/2001/04/xmldsig-more#ECDSA_sha224'
-SIG_ECDSA_SHA256 = 'http://www.w3.org/2001/04/xmldsig-more#ECDSA_sha256'
-SIG_ECDSA_SHA384 = 'http://www.w3.org/2001/04/xmldsig-more#ECDSA_sha384'
-SIG_ECDSA_SHA512 = 'http://www.w3.org/2001/04/xmldsig-more#ECDSA_sha512'
+SIG_ECDSA_SHA1 = 'http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1'
+SIG_ECDSA_SHA224 = 'http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha224'
+SIG_ECDSA_SHA256 = 'http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256'
+SIG_ECDSA_SHA384 = 'http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384'
+SIG_ECDSA_SHA512 = 'http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512'
 SIG_RSA_MD5 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-md5'  # test framework
 SIG_RSA_SHA1 = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
 SIG_RSA_SHA224 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha224'


### PR DESCRIPTION
The constants for ecdsa algorithms are wrong, so they are discarded when generating the supported algorithms from xmlsec (which does support them).

These are the reported supported algo's by xmlsec's latest release
```shell
mhindery@Mathieus-MacBook-Pro usermanagement % xmlsec1 --version        
xmlsec1 1.2.30 (openssl)
mhindery@Mathieus-MacBook-Pro usermanagement % xmlsec1 --list-transforms
Registered transform klasses:
"base64","enveloped-signature","c14n","c14n-with-comments","c14n11","c14n11-with-comments","exc-c14n","exc-c14n-with-comments","xpath","xpath2","xpointer","relationship","xslt","aes128-cbc","aes192-cbc","aes256-cbc","aes128-gcm","aes192-gcm","aes256-gcm","kw-aes128","kw-aes192","kw-aes256","tripledes-cbc","kw-tripledes","dsa-sha1","dsa-sha256","ecdsa-sha1","ecdsa-sha224","ecdsa-sha256","ecdsa-sha384","ecdsa-sha512","hmac-md5","hmac-ripemd160","hmac-sha1","hmac-sha224","hmac-sha256","hmac-sha384","hmac-sha512","md5","ripemd160","rsa-md5","rsa-ripemd160","rsa-sha1","rsa-sha224","rsa-sha256","rsa-sha384","rsa-sha512","rsa-1_5","rsa-oaep-mgf1p","sha1","sha224","sha256","sha384","sha512"
mhindery@Mathieus-MacBook-Pro usermanagement % 
```

Note particularly the entries `"ecdsa-sha1","ecdsa-sha224","ecdsa-sha256","ecdsa-sha384","ecdsa-sha512"`, which have a dash in their name, while the code mapping currently has them with an underscore in them, so they are not recognized.

Additionally, the mapping has uppercase `ECDSA` with the underscore, while it should be lowercase with a dash. See e.g.:
- https://tools.ietf.org/html/rfc6931#section-2.3.6
- https://www.w3.org/TR/xmlsec-algorithms/#ECDSA



