### PR TITLE
Replace assert statements

### DIFF
--- a/src/saml2/__init__.py
+++ b/src/saml2/__init__.py
@@ -822,9 +822,7 @@ class SamlBase(ExtensionContainer):
                 self.text = None
 
     def __eq__(self, other):
-        try:
-            assert isinstance(other, SamlBase)
-        except AssertionError:
+        if not isinstance(other, SamlBase):
             return False
 
         self.clear_text()

--- a/src/saml2/assertion.py
+++ b/src/saml2/assertion.py
@@ -296,9 +296,7 @@ def post_entity_categories(maps, **kwargs):
                         else:
                             attrs = atlist
                         for _key in key:
-                            try:
-                                assert _key in ecs
-                            except AssertionError:
+                            if _key not in ecs:
                                 attrs = []
                                 break
                     elif key in ecs:

--- a/src/saml2/authn_context/__init__.py
+++ b/src/saml2/authn_context/__init__.py
@@ -90,7 +90,9 @@ class AuthnBroker(object):
         if _ref is None:
             _ref = str(self.next)
 
-        assert _ref not in self.db["info"]
+        if _ref in self.db["info"]:
+            raise Exception("Internal error: reference is not unique")
+
         self.db["info"][_ref] = _info
         try:
             self.db["key"][key].append(_ref)

--- a/src/saml2/client.py
+++ b/src/saml2/client.py
@@ -75,7 +75,12 @@ class Saml2Client(Base):
                 response_binding=response_binding,
                 **kwargs)
 
-        assert negotiated_binding == binding
+        if negotiated_binding != binding:
+            raise ValueError(
+                "Negotiated binding '{}' does not match binding to use '{}'".format(
+                    negotiated_binding, binding
+                )
+            )
 
         return reqid, info
 

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -646,8 +646,10 @@ class Base(Entity):
         :return:
         """
 
-        # One of them must be present
-        assert name_id or base_id or encrypted_id
+        if not name_id and not base_id and not encrypted_id:
+            raise ValueError(
+                "At least one of name_id, base_id or encrypted_id must be present."
+            )
 
         if name_id:
             return self._message(NameIDMappingRequest, destination, message_id,

--- a/src/saml2/ecp_client.py
+++ b/src/saml2/ecp_client.py
@@ -136,7 +136,14 @@ class Client(Entity):
         logger.debug("[P2] IdP response dict: %s", respdict)
 
         idp_response = respdict["body"]
-        assert idp_response.c_tag == "Response"
+
+        expected_tag = "Response"
+        if idp_response.c_tag != expected_tag:
+            raise ValueError(
+                "Invalid Response tag '{invalid}' should be '{valid}'".format(
+                    invalid=idp_response.c_tag, valid=expected_tag
+                )
+            )
 
         logger.debug("[P2] IdP AUTHN response: %s", idp_response)
 
@@ -165,7 +172,14 @@ class Client(Entity):
 
         # AuthnRequest in the body or not
         authn_request = respdict["body"]
-        assert authn_request.c_tag == "AuthnRequest"
+
+        expected_tag = "AuthnRequest"
+        if authn_request.c_tag != expected_tag:
+            raise ValueError(
+                "Invalid AuthnRequest tag '{invalid}' should be '{valid}'".format(
+                    invalid=authn_request.c_tag, valid=expected_tag
+                )
+            )
 
         # ecp.RelayState among headers
         _relay_state = None

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -848,7 +848,7 @@ class Entity(HTTPBase):
         _log_debug("Loaded request")
 
         if _request:
-            _request = _request.verify()
+            _request.verify()
             _log_debug("Verified request")
 
         if not _request:
@@ -1192,14 +1192,14 @@ class Entity(HTTPBase):
             response.require_signature = True
             # Verify that the assertion is syntactically correct and the
             # signature on the assertion is correct if present.
-            response = response.verify(keys)
+            response.verify(keys)
         except SignatureError as err:
             if require_signature:
                 logger.error("Signature Error: %s", err)
                 raise
             else:
                 response.require_signature = require_signature
-                response = response.verify(keys)
+                response.verify(keys)
         else:
             assertions_are_signed = True
         finally:
@@ -1260,7 +1260,13 @@ class Entity(HTTPBase):
 
         _art = base64.b64decode(artifact)
 
-        assert _art[:2] == ARTIFACT_TYPECODE
+        typecode = _art[:2]
+        if typecode != ARTIFACT_TYPECODE:
+            raise ValueError(
+                "Invalid artifact typecode '{invalid}' should be {valid}".format(
+                    invalid=typecode, valid=ARTIFACT_TYPECODE
+                )
+            )
 
         try:
             endpoint_index = str(int(_art[2:4]))

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -405,9 +405,7 @@ class MetaData(object):
         return res
 
     def __eq__(self, other):
-        try:
-            assert isinstance(other, MetaData)
-        except AssertionError:
+        if not isinstance(other, MetaData):
             return False
 
         if len(self.entity) != len(other.entity):
@@ -417,9 +415,7 @@ class MetaData(object):
             return False
 
         for key, item in self.entity.items():
-            try:
-                assert item == other[key]
-            except AssertionError:
+            if item != other[key]:
                 return False
 
         return True

--- a/src/saml2/pack.py
+++ b/src/saml2/pack.py
@@ -179,7 +179,10 @@ def http_redirect_message(message, location, relay_state="", typ="SAMLRequest",
 
     if signer:
         # sigalgs, should be one defined in xmldsig
-        assert sigalg in [b for a, b in SIG_ALLOWED_ALG]
+        if sigalg not in [long_name for short_name, long_name in SIG_ALLOWED_ALG]:
+            raise Exception(
+                "Signature algo not in allowed list: {algo}".format(algo=sigalg)
+            )
         args["SigAlg"] = sigalg
 
         string = "&".join([urlencode({k: args[k]})
@@ -269,7 +272,14 @@ def parse_soap_enveloped_saml(text, body_class, header_class=None):
     :return: header parts and body as saml.samlbase instances
     """
     envelope = defusedxml.ElementTree.fromstring(text)
-    assert envelope.tag == '{%s}Envelope' % NAMESPACE
+
+    envelope_tag = "{%s}Envelope" % NAMESPACE
+    if envelope.tag != envelope_tag:
+        raise ValueError(
+            "Invalid envelope tag '{invalid}' should be '{valid}'".format(
+                invalid=envelope.tag, valid=envelope_tag
+            )
+        )
 
     # print(len(envelope))
     body = None

--- a/src/saml2/request.py
+++ b/src/saml2/request.py
@@ -80,15 +80,21 @@ class Request(object):
         return issued_at > lower and issued_at < upper
 
     def _verify(self):
-        assert self.message.version == "2.0"
+        valid_version = "2.0"
+        if self.message.version != valid_version:
+            raise VersionMismatch(
+                "Invalid version {invalid} should be {valid}".format(
+                    invalid=self.message.version, valid=valid_version
+                )
+            )
+
         if self.message.destination and self.receiver_addrs and \
                 self.message.destination not in self.receiver_addrs:
-            logger.error("%s not in %s", self.message.destination,
-                                         self.receiver_addrs)
+            logger.error("%s not in %s", self.message.destination, self.receiver_addrs)
             raise OtherError("Not destined for me!")
 
-        assert self.issue_instant_ok()
-        return self
+        valid = self.issue_instant_ok()
+        return valid
 
     def loads(self, xmldata, binding, origdoc=None, must=None,
               only_valid_cert=False):

--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -116,8 +116,14 @@ class AttributeValueBase(SamlBase):
 
     def verify(self):
         if not self.text:
-            assert self.extension_attributes
-            assert self.extension_attributes[XSI_NIL] == "true"
+            if not self.extension_attributes:
+                raise Exception(
+                    "Attribute value base should not have extension attributes"
+                )
+            if self.extension_attributes[XSI_NIL] != "true":
+                raise Exception(
+                    "Attribute value base should not have extension attributes"
+                )
             return True
         else:
             SamlBase.verify(self)
@@ -1029,12 +1035,11 @@ class AuthnContextType_(SamlBase):
         self.authenticating_authority = authenticating_authority or []
 
     def verify(self):
-        # either <AuthnContextDecl> or <AuthnContextDeclRef> not both
-        if self.authn_context_decl:
-            assert self.authn_context_decl_ref is None
-        elif self.authn_context_decl_ref:
-            assert self.authn_context_decl is None
-
+        if self.authn_context_decl and self.authn_context_decl_ref:
+            raise Exception(
+                "Invalid Response: "
+                "Cannot have both <AuthnContextDecl> and <AuthnContextDeclRef>"
+            )
         return SamlBase.verify(self)
 
 
@@ -1264,9 +1269,11 @@ class ConditionsType_(SamlBase):
 
     def verify(self):
         if self.one_time_use:
-            assert len(self.one_time_use) == 1
+            if len(self.one_time_use) != 1:
+                raise Exception("Cannot be used more than once")
         if self.proxy_restriction:
-            assert len(self.proxy_restriction) == 1
+            if len(self.proxy_restriction) != 1:
+                raise Exception("Cannot be used more than once")
 
         return SamlBase.verify(self)
 

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -356,7 +356,8 @@ M2_TIME_FORMAT = '%b %d %H:%M:%S %Y'
 
 
 def to_time(_time):
-    assert _time.endswith(' GMT')
+    if not _time.endswith(' GMT'):
+        raise Exception('Time does not end with GMT')
     _time = _time[:-4]
     return mktime(str_to_time(_time, M2_TIME_FORMAT))
 
@@ -372,8 +373,10 @@ def active_cert(key):
     try:
         cert_str = pem_format(key)
         cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert_str)
-        assert cert.has_expired() == 0
-        assert not OpenSSLWrapper().certificate_not_valid_yet(cert)
+        if not cert.has_expired() == 0:
+            raise Exception('Cert is expired.')
+        if  OpenSSLWrapper().certificate_not_valid_yet(cert):
+            raise Exception('Certificate not valid yet.')
         return True
     except AssertionError:
         return False

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -679,7 +679,8 @@ class CryptoBackendXmlSec1(CryptoBackend):
 
     def __init__(self, xmlsec_binary, delete_tmpfiles=True, **kwargs):
         CryptoBackend.__init__(self, **kwargs)
-        assert (isinstance(xmlsec_binary, six.string_types))
+        if not isinstance(xmlsec_binary, six.string_types):
+            raise ValueError("xmlsec_binary should be of type string")
         self.xmlsec = xmlsec_binary
         self.delete_tmpfiles = delete_tmpfiles
         try:
@@ -1237,11 +1238,12 @@ class SecurityContext(object):
             sec_backend=None,
             delete_tmpfiles=True):
 
+        if not isinstance(crypto, CryptoBackend):
+            raise ValueError("crypto should be of type CryptoBackend")
         self.crypto = crypto
-        assert (isinstance(self.crypto, CryptoBackend))
 
-        if sec_backend:
-            assert (isinstance(sec_backend, RSACrypto))
+        if sec_backend and not isinstance(sec_backend, RSACrypto):
+            raise ValueError("sec_backend should be of type RSACrypto")
         self.sec_backend = sec_backend
 
         # Your private key for signing

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -357,7 +357,7 @@ M2_TIME_FORMAT = '%b %d %H:%M:%S %Y'
 
 def to_time(_time):
     if not _time.endswith(' GMT'):
-        raise Exception('Time does not end with GMT')
+        raise ValueError('Time does not end with GMT')
     _time = _time[:-4]
     return mktime(str_to_time(_time, M2_TIME_FORMAT))
 

--- a/src/saml2/time_util.py
+++ b/src/saml2/time_util.py
@@ -68,7 +68,7 @@ def parse_duration(duration):
     else:
         sign = '+'
     if duration[index] != "P":
-        raise Exception('Parse Duration is not valid.')
+        raise ValueError('Parse Duration is not valid.')
     index += 1
 
     dic = dict([(typ, 0) for (code, typ) in D_FORMAT if typ])
@@ -77,14 +77,14 @@ def parse_duration(duration):
     for code, typ in D_FORMAT:
         #print(duration[index:], code)
         if duration[index] == '-':
-            raise Exception("Negation not allowed on individual items")
+            raise ValueError("Negation not allowed on individual items")
         if code == "T":
             if duration[index] == "T":
                 index += 1
                 if index == len(duration):
-                    raise Exception("Not allowed to end with 'T'")
+                    raise ValueError("Not allowed to end with 'T'")
             else:
-                raise Exception("Missing T")
+                raise ValueError("Missing T")
         elif duration[index] == "T":
             continue
         else:

--- a/src/saml2/time_util.py
+++ b/src/saml2/time_util.py
@@ -67,7 +67,8 @@ def parse_duration(duration):
         index += 1
     else:
         sign = '+'
-    assert duration[index] == "P"
+    if duration[index] != "P":
+        raise Exception('Parse Duration is not valid.')
     index += 1
 
     dic = dict([(typ, 0) for (code, typ) in D_FORMAT if typ])

--- a/src/saml2/validate.py
+++ b/src/saml2/validate.py
@@ -425,12 +425,6 @@ def valid_instance(instance):
                     "Class '%s' instance cardinality error: %s" % (
                         class_name, "too few values on %s" % name))
 
-#    if not _has_val:
-#        if class_name != "RequestedAttribute":
-#            # Not allow unless xsi:nil="true"
-#            assert instance.extension_attributes
-#            assert instance.extension_attributes[XSI_NIL] == "true"
-
     return True
 
 


### PR DESCRIPTION
This PR is a Work in Progress that would remove all the occourrence of `asset` statement in the code (excluding those belonging to unit tests).

This also would fixes the following issue, it would guarantee superior computational performance as well.
https://github.com/IdentityPython/pysaml2/issues/451

I started with few changes but I'd think to have specialized Exception for each removed `Assert`