### PR TITLE
Update to 2048 bits in create_key.sh

### DIFF
--- a/example/create_key.sh
+++ b/example/create_key.sh
@@ -7,7 +7,7 @@ by openssl, edit your openssl.cnf, such as /etc/ssl/openssl.cnf
 
 EOF
 
-openssl genrsa -out server.key 1024
+openssl genrsa -out server.key 2048
 chmod 600 server.key
 openssl req -new -key server.key -out server.csr
 openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt


### PR DESCRIPTION
Increase key size in demo key generation will prevent following error:
 ssl.SSLError: [SSL: EE_KEY_TOO_SMALL] ee key too small (_ssl.c:3542)

Choosing to increase the key size is preferable to defanging the ssl libraries to encourage them to accept them, even for demo use.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [n/a] Have you written new tests for your changes?
* [n/a] Does your submission pass tests?
* [n/a] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


Note that the pre-bundled certs are still 1024 bit so need to be regenerated before use.  This PR does not attempt to update those.
