### PR TITLE
Add option to sign logout response

### DIFF
--- a/docs/howto/config.rst
+++ b/docs/howto/config.rst
@@ -987,6 +987,24 @@ Example::
         }
     }
 
+logout_responses_signed
+"""""""""""""""""""""""
+
+Indicates if this entity will sign the Logout Responses while processing
+a Logout Request.
+
+This can be overridden by application code when calling ``handle_logout_request``.
+
+Valid values are True or False. Default value is False.
+
+Example::
+
+    "service": {
+        "sp": {
+            "logout_responses_signed": False,
+        }
+    }
+
 subject_data
 """"""""""""
 

--- a/src/saml2/client.py
+++ b/src/saml2/client.py
@@ -487,7 +487,7 @@ class Saml2Client(Base):
         else:
             raise SAMLError("Unsupported binding")
 
-    def handle_logout_request(self, request, name_id, binding, sign=False,
+    def handle_logout_request(self, request, name_id, binding, sign=None,
                               sign_alg=None, relay_state=""):
         """
         Deal with a LogoutRequest
@@ -533,6 +533,9 @@ class Saml2Client(Base):
         else:
             response_bindings = self.config.preferred_binding[
                 "single_logout_service"]
+
+        if sign is None:
+            sign = self.logout_responses_signed
 
         response = self.create_logout_response(_req.message, response_bindings,
                                                status, sign, sign_alg=sign_alg)

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -162,6 +162,7 @@ class Base(Entity):
 
         attribute_defaults = {
             "logout_requests_signed": False,
+            "logout_responses_signed": False,
             "allow_unsolicited": False,
             "authn_requests_signed": False,
             "want_assertions_signed": False,

--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -95,6 +95,7 @@ SP_ARGS = [
     "name_id_policy_format",
     "name_id_format_allow_create",
     "logout_requests_signed",
+    "logout_responses_signed",
     "requested_attribute_name_format",
     "hide_assertion_consumer_service",
     "force_authn",
@@ -201,6 +202,7 @@ class Config(object):
         self.virtual_organization = None
         self.only_use_keys_in_metadata = True
         self.logout_requests_signed = None
+        self.logout_responses_signed = None
         self.disable_ssl_certificate_validation = None
         self.context = ""
         self.attribute_converters = None

--- a/tests/server_conf.py
+++ b/tests/server_conf.py
@@ -14,6 +14,8 @@ CONFIG = {
             "required_attributes": ["surName", "givenName", "mail"],
             "optional_attributes": ["title"],
             "idp": ["urn:mace:example.com:saml:roland:idp"],
+            "logout_responses_signed": True,
+            "logout_requests_signed": True,
             "requested_attributes": [
                 {
                     "name": "urn:oid:1.3.6.1.4.1.5923.1.1.1.2",


### PR DESCRIPTION
As discussed in #733, this PR adds a new option to sign logout responses when calling applications are not explicit about it. 

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



