### PR TITLE
Include status-code in http_info struct

### DIFF
--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -241,7 +241,7 @@ class Entity(HTTPBase):
             if response:
                 info = self.use_http_artifact(msg_str, destination, relay_state)
                 info["method"] = "GET"
-                info["status"] = 302
+                info["status"] = 302  # TODO: should be 303 on >= HTTP/1.1
             else:
                 info = self.use_http_artifact(msg_str, destination, relay_state)
         else:

--- a/src/saml2/pack.py
+++ b/src/saml2/pack.py
@@ -111,7 +111,7 @@ def http_form_post_message(message, location, relay_state="",
         relay_state_input=relay_state_input,
         action=location)
 
-    return {"headers": [("Content-type", "text/html")], "data": response}
+    return {"headers": [("Content-type", "text/html")], "data": response, "status": 200}
 
 
 def http_post_message(message, relay_state="", typ="SAMLRequest", **kwargs):
@@ -137,7 +137,8 @@ def http_post_message(message, relay_state="", typ="SAMLRequest", **kwargs):
         part["RelayState"] = relay_state
 
     return {"headers": [("Content-type", 'application/x-www-form-urlencoded')],
-            "data": urlencode(part)}
+            "data": urlencode(part),
+            "status": 200}
 
 
 def http_redirect_message(message, location, relay_state="", typ="SAMLRequest",
@@ -197,7 +198,7 @@ def http_redirect_message(message, location, relay_state="", typ="SAMLRequest",
     headers = [('Location', str(login_url))]
     body = []
 
-    return {"headers": headers, "data": body}
+    return {"headers": headers, "data": body, "status": 303}
 
 
 DUMMY_NAMESPACE = "http://example.org/"
@@ -257,12 +258,14 @@ def make_soap_enveloped_saml_thingy(thingy, header_parts=None):
 
 def http_soap_message(message):
     return {"headers": [("Content-type", "application/soap+xml")],
-            "data": make_soap_enveloped_saml_thingy(message)}
+            "data": make_soap_enveloped_saml_thingy(message),
+            "status": 200}
 
 
 def http_paos(message, extra=None):
     return {"headers": [("Content-type", "application/soap+xml")],
-            "data": make_soap_enveloped_saml_thingy(message, extra)}
+            "data": make_soap_enveloped_saml_thingy(message, extra),
+            "status": 200}
 
 
 def parse_soap_enveloped_saml(text, body_class, header_class=None):

--- a/tests/fakeIDP.py
+++ b/tests/fakeIDP.py
@@ -130,6 +130,7 @@ class FakeIDP(Server):
         _dict = pack.factory(_binding, response,
                              resp_args["destination"], relay_state,
                              "SAMLResponse")
+        _dict.pop('status')
         return DummyResponse(200, **_dict)
 
     def attribute_query_endpoint(self, xml_str, binding):

--- a/tests/fakeIDP.py
+++ b/tests/fakeIDP.py
@@ -43,8 +43,8 @@ def unpack_form(_str, ver="SAMLRequest"):
 
 
 class DummyResponse(object):
-    def __init__(self, code, data, headers=None):
-        self.status_code = code
+    def __init__(self, status, data, headers=None):
+        self.status_code = status
         self.text = data
         self.headers = headers or []
         self.content = data
@@ -130,8 +130,7 @@ class FakeIDP(Server):
         _dict = pack.factory(_binding, response,
                              resp_args["destination"], relay_state,
                              "SAMLResponse")
-        _dict.pop('status')
-        return DummyResponse(200, **_dict)
+        return DummyResponse(**_dict)
 
     def attribute_query_endpoint(self, xml_str, binding):
         if binding == BINDING_SOAP:
@@ -161,7 +160,7 @@ class FakeIDP(Server):
         else:  # Just POST
             response = "%s" % attr_resp
 
-        return DummyResponse(200, response)
+        return DummyResponse(status=200, data=response)
 
     def logout_endpoint(self, xml_str, binding):
         if binding == BINDING_SOAP:
@@ -186,4 +185,4 @@ class FakeIDP(Server):
         else: # Just POST
             response = "%s" % _resp
 
-        return DummyResponse(200, response)
+        return DummyResponse(status=200, data=response)

--- a/tests/test_50_server.py
+++ b/tests/test_50_server.py
@@ -2311,9 +2311,10 @@ class TestServerLogout():
                 binding, "%s" % response, destination, "relay_state", response=True
             )
 
-            assert len(http_args) == 4
+            assert len(http_args) == 5
             assert http_args["headers"][0][0] == "Location"
             assert http_args["data"] == []
+            assert http_args["status"] == 303
             assert http_args['url'] == 'http://lingon.catalogix.se:8087/sloresp'
 
     def test_2(self):
@@ -2330,10 +2331,11 @@ class TestServerLogout():
                 binding, "%s" % response, destination, "relay_state", response=True
             )
 
-            assert len(http_args) == 4
+            assert len(http_args) == 5
             assert len(http_args["data"]) > 0
             assert http_args["method"] == "POST"
             assert http_args['url'] == 'http://lingon.catalogix.se:8087/slo'
+            assert http_args['status'] == 200
 
 
 if __name__ == "__main__":

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -3249,7 +3249,6 @@ class TestClientWithDummy():
         # Here I fake what the client will do
         # create the form post
 
-        http_args.pop('status')
         http_args["data"] = parse.urlencode(_dic)
         http_args["method"] = "POST"
         http_args["dummy"] = _dic["SAMLRequest"]
@@ -3286,7 +3285,6 @@ class TestClientWithDummy():
         # Here I fake what the client will do
         # create the form post
 
-        http_args.pop('status')
         http_args["data"] = parse.urlencode(_dic)
         http_args["method"] = "POST"
         http_args["dummy"] = _dic["SAMLRequest"]

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -3167,9 +3167,10 @@ class TestClientWithDummy():
             binding=binding, response_binding=response_binding)
 
         assert isinstance(sid, six.string_types)
-        assert len(http_args) == 4
+        assert len(http_args) == 5
         assert http_args["headers"][0][0] == "Location"
         assert http_args["data"] == []
+        assert http_args["status"] == 303
         redirect_url = http_args["headers"][0][1]
         _, _, _, _, qs, _ = parse.urlparse(redirect_url)
         qs_dict = parse.parse_qs(qs)
@@ -3188,9 +3189,10 @@ class TestClientWithDummy():
 
         assert binding == auth_binding
         assert isinstance(sid, six.string_types)
-        assert len(http_args) == 4
+        assert len(http_args) == 5
         assert http_args["headers"][0][0] == "Location"
         assert http_args["data"] == []
+        assert http_args["status"] == 303
         redirect_url = http_args["headers"][0][1]
         _, _, _, _, qs, _ = parse.urlparse(redirect_url)
         qs_dict = parse.parse_qs(qs)
@@ -3247,6 +3249,7 @@ class TestClientWithDummy():
         # Here I fake what the client will do
         # create the form post
 
+        http_args.pop('status')
         http_args["data"] = parse.urlencode(_dic)
         http_args["method"] = "POST"
         http_args["dummy"] = _dic["SAMLRequest"]
@@ -3283,6 +3286,7 @@ class TestClientWithDummy():
         # Here I fake what the client will do
         # create the form post
 
+        http_args.pop('status')
         http_args["data"] = parse.urlencode(_dic)
         http_args["method"] = "POST"
         http_args["dummy"] = _dic["SAMLRequest"]


### PR DESCRIPTION
Fix #242 - make sure status code is always returned in `http_info` dict.

*we still need to switch between 302 and 303 depending on the HTTP protocol version (1.1 or newer).


### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?