### PR TITLE
Fix test_33_identifier.py to avoid reuse of old test data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ example/*/modules/
 
 tests/*.log.*
 tests/*.db
+tests/*.dir
+tests/*.dat
+tests/*.bak
+
 
 eptid
 
@@ -116,6 +120,9 @@ venv.bak/
 
 # Visual Studio Code files
 .vscode/
+
+# PyCharm project files
+.idea/
 
 # mkdocs documentation
 /site

--- a/tests/test_33_identifier.py
+++ b/tests/test_33_identifier.py
@@ -7,34 +7,39 @@ from saml2.config import IdPConfig
 from saml2.ident import IdentDB
 from saml2.assertion import Policy
 
-def _eq(l1,l2):
+from pathutils import full_path
+
+
+def _eq(l1, l2):
     return set(l1) == set(l2)
 
+
 CONFIG = IdPConfig().load({
-    "entityid" :  "urn:mace:example.com:idp:2",
-    "name" : "test",
+    "entityid": "urn:mace:example.com:idp:2",
+    "name": "test",
     "service": {
         "idp": {
-            "endpoints" : {
-                "single_sign_on_service" : ["http://idp.example.org/"],
-                },
+            "endpoints": {
+                "single_sign_on_service": ["http://idp.example.org/"],
+            },
             "policy": {
                 "default": {
-                    "lifetime": {"minutes":15},
-                    "attribute_restrictions": None, # means all I have
-                    "name_form": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+                    "lifetime": {"minutes": 15},
+                    "attribute_restrictions": None,  # means all I have
+                    "name_form":
+                        "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
                     "nameid_format": NAMEID_FORMAT_PERSISTENT
                 }
             }
         }
     },
-    "virtual_organization" : {
-        "http://vo.example.org/biomed":{
-            "nameid_format" : "urn:oid:2.16.756.1.2.5.1.1.1-NameID",
+    "virtual_organization": {
+        "http://vo.example.org/biomed": {
+            "nameid_format": "urn:oid:2.16.756.1.2.5.1.1.1-NameID",
             "common_identifier": "uid",
         },
-        "http://vo.example.org/design":{
-            "nameid_format" : NAMEID_FORMAT_PERSISTENT,
+        "http://vo.example.org/design": {
+            "nameid_format": NAMEID_FORMAT_PERSISTENT,
             "common_identifier": "uid",
         }
     }
@@ -53,13 +58,14 @@ NAME_ID_POLICY_2 = """<?xml version="1.0" encoding="utf-8"?>
 """
 
 
-class TestIdentifier():
+class TestIdentifier:
     def setup_class(self):
-        try:
-            os.remove("subject.db.db")
-        except:
-            pass
-        self.id = IdentDB("subject.db", "example.com", "example")
+        for extension in ('.db', '.dir', '.dat', '.bak'):
+            try:
+                os.remove(full_path("subject.db{}".format(extension)))
+            except (OSError, IOError):
+                pass
+        self.id = IdentDB(full_path("subject.db"), "example.com", "example")
 
     def test_persistent_1(self):
         policy = Policy({
@@ -80,9 +86,9 @@ class TestIdentifier():
         assert nameid.sp_name_qualifier == "urn:mace:example.com:sp:1"
         assert nameid.format == NAMEID_FORMAT_PERSISTENT
 
-        id = self.id.find_local_id(nameid)
+        id_ = self.id.find_local_id(nameid)
 
-        assert id == "foobar"
+        assert id_ == "foobar"
 
     def test_persistent_2(self):
         userid = 'foobar'
@@ -161,7 +167,6 @@ class TestIdentifier():
         assert nameid.format == NAMEID_FORMAT_PERSISTENT
         assert nameid.text != "foobar01"
 
-
     def test_persistent_nameid(self):
         sp_id = "urn:mace:umu.se:sp"
         nameid = self.id.persistent_nameid("abcd0001", sp_id)
@@ -187,6 +192,5 @@ class TestIdentifier():
         assert nameid.text.strip() != nameid2.text.strip()
 
     def teardown_class(self):
-        if os.path.exists("subject.db"):
-            os.unlink("subject.db")
-
+        if os.path.exists(full_path("subject.db")):
+            os.unlink(full_path("subject.db"))

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
   py36
   py37
   py38
+  py39
   pypy3
 
 [testenv]


### PR DESCRIPTION
  - If for any reason the dbm.dumb is used for saving subject.db
    data the following tests can fail because subject.db.dat and
    subject.db.dir are not removed. To avoid this additional deletes
    of test data files are added to setup_class().
  - Add also _tests/*.dir_, _tests/*.dat_, _tests/*.bak_ to .gitignore to
    prevent erroneous adding of test data to the repository
  - Use full_path() helper to create the test data files under tests/
  - Add py39 to tox.ini envlist
  - Add _.idea/_ to .gitignore
 

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



