### PR TITLE
Fail installing on Python < 3.6.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     pytz
     requests >= 1.0.0
     six
+python_requires = ~=3.6
 
 
 [options.packages.find]


### PR DESCRIPTION
Fixes #749.

This causes pip to show an error message during install on Python 3.5:

> ERROR: Package 'pysaml2' requires a different Python: 3.5.9 not in '~=3.6'

Instead of causing errors during runtime only.