### PR TITLE
Update of SWAMID policy regarding eduPersonTargetedID when no entity category is used

### DIFF
--- a/src/saml2/entity_category/swamid.py
+++ b/src/saml2/entity_category/swamid.py
@@ -71,7 +71,7 @@ NREN = 'http://www.swamid.se/category/nren-service'          # Deprecated from 2
 HEI = 'http://www.swamid.se/category/hei-service'            # Deprecated from 2021-03-31
 
 RELEASE = {
-    '': ['eduPersonTargetedID'],
+    '': [''],
     SFS_1993_1153: ['norEduPersonNIN', 'eduPersonAssurance'],
     (RESEARCH_AND_EDUCATION, EU): NAME + STATIC_ORG_INFO + OTHER,
     (RESEARCH_AND_EDUCATION, NREN): NAME + STATIC_ORG_INFO + OTHER,

--- a/tests/test_37_entity_categories.py
+++ b/tests/test_37_entity_categories.py
@@ -102,7 +102,7 @@ def test_filter_ava3():
     }
 
     ava = policy.filter(ava, "urn:mace:example.com:saml:roland:sp")
-    assert _eq(list(ava.keys()), ['eduPersonTargetedID', "norEduPersonNIN"])
+    assert _eq(list(ava.keys()), ["norEduPersonNIN"])
 
 
 def test_filter_ava4():
@@ -131,7 +131,7 @@ def test_filter_ava4():
 
     ava = policy.filter(ava, "urn:mace:example.com:saml:roland:sp")
     assert _eq(
-        list(ava.keys()), ['eduPersonTargetedID', "givenName", "c", "mail", "sn"]
+        list(ava.keys()), ["givenName", "c", "mail", "sn"]
     )
 
 
@@ -160,7 +160,7 @@ def test_filter_ava5():
 
     ava = policy.filter(ava, "urn:mace:example.com:saml:roland:sp")
 
-    assert _eq(list(ava.keys()), ['eduPersonTargetedID'])
+    assert _eq(list(ava.keys()), [])
 
 
 def test_idp_policy_filter():


### PR DESCRIPTION
According to SWAMID policy no attributes should be released when entity category is missing.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



