### PR TITLE
No eduPersonTargetedID for entity category refeds research-and-scholarship

### DIFF
--- a/src/saml2/entity_category/swamid.py
+++ b/src/saml2/entity_category/swamid.py
@@ -24,7 +24,6 @@ OTHER = [
 ]
 
 R_AND_S = [
-    'eduPersonTargetedID',
     'eduPersonPrincipalName',
     'eduPersonUniqueID',
     'mail',


### PR DESCRIPTION
According to SWAMID policy eduPersonTargetedID should not be released for entity category refeds research-and-scholarship

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



