### PR TITLE
[Strengthen Encryption] PySAML2 Encrypted Assertions work with Shibboleth SP 3

### DIFF
--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -660,8 +660,12 @@ class Entity(HTTPBase):
                 tmp = make_temp(_cert.encode('ascii'),
                                 decode=False,
                                 delete_tmpfiles=self.config.delete_tmpfiles)
+                
+                # it would be possibile to handle many other args here ...
+                pre_enc_part = pre_encryption_part(encrypt_cert=encrypt_cert)
+                
                 response = self.sec.encrypt_assertion(response, tmp.name,
-                                                      pre_encryption_part(),
+                                                      pre_enc_part,
                                                       node_xpath=node_xpath)
                 return response
             except Exception as ex:

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -1850,7 +1850,8 @@ def pre_signature_part(
 
 
 def pre_encryption_part(msg_enc=TRIPLE_DES_CBC, key_enc=RSA_1_5, key_name='my-rsa-key',
-        encrypted_key_id=None, encrypted_data_id=None):
+        encrypted_key_id=None, encrypted_data_id=None,
+        encrypt_cert=None):
     """
 
     :param msg_enc:
@@ -1865,7 +1866,10 @@ def pre_encryption_part(msg_enc=TRIPLE_DES_CBC, key_enc=RSA_1_5, key_name='my-rs
     encrypted_key = EncryptedKey(
         id=ek_id,
         encryption_method=key_encryption_method,
-        key_info=ds.KeyInfo(key_name=ds.KeyName(text=key_name)),
+        key_info=ds.KeyInfo(key_name=ds.KeyName(text=key_name),
+                            x509_data=ds.X509Data(
+                            x509_certificate=ds.X509Certificate(text=encrypt_cert)
+                        )),
         cipher_data=CipherData(cipher_value=CipherValue(text='')),
     )
     key_info = ds.KeyInfo(encrypted_key=encrypted_key)

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 SIG = '{{{ns}#}}{attribute}'.format(ns=ds.NAMESPACE, attribute='Signature')
 
 # deprecated 
-RSA_1_5 = 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
+# RSA_1_5 = 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
 
 TRIPLE_DES_CBC = 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'
 RSA_OAEP = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"
@@ -754,7 +754,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
         :param key_type: The type of session key to use.
         :return: The encrypted text
         """
-
+        
         if isinstance(statement, SamlBase):
             statement = pre_encrypt_assertion(statement)
 
@@ -1293,7 +1293,7 @@ class SecurityContext(object):
 
         self.metadata = metadata
         self.only_use_keys_in_metadata = only_use_keys_in_metadata
-
+        
         if not template:
             this_dir, this_filename = os.path.split(__file__)
             self.template = os.path.join(this_dir, 'xml_template', 'template.xml')
@@ -1866,13 +1866,17 @@ def pre_encryption_part(msg_enc=TRIPLE_DES_CBC, key_enc=RSA_OAEP,
     ed_id = encrypted_data_id or "ED_{id}".format(id=gen_random_key())
     msg_encryption_method = EncryptionMethod(algorithm=msg_enc)
     key_encryption_method = EncryptionMethod(algorithm=key_enc)
+    
+    enc_key_dict= dict(key_name=ds.KeyName(text=key_name))
+    
+    enc_key_dict['x509_data'] = ds.X509Data(
+        x509_certificate=ds.X509Certificate(text=encrypt_cert))
+    key_info = ds.KeyInfo(**enc_key_dict)
+    
     encrypted_key = EncryptedKey(
         id=ek_id,
         encryption_method=key_encryption_method,
-        key_info=ds.KeyInfo(key_name=ds.KeyName(text=key_name),
-                            x509_data=ds.X509Data(
-                            x509_certificate=ds.X509Certificate(text=encrypt_cert)
-                        )),
+        key_info=key_info,
         cipher_data=CipherData(cipher_value=CipherValue(text='')),
     )
     key_info = ds.KeyInfo(encrypted_key=encrypted_key)

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -61,9 +61,11 @@ logger = logging.getLogger(__name__)
 
 SIG = '{{{ns}#}}{attribute}'.format(ns=ds.NAMESPACE, attribute='Signature')
 
+# deprecated 
 RSA_1_5 = 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
-TRIPLE_DES_CBC = 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'
 
+TRIPLE_DES_CBC = 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'
+RSA_OAEP = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"
 
 class SigverError(SAMLError):
     pass
@@ -1849,7 +1851,8 @@ def pre_signature_part(
 # </EncryptedData>
 
 
-def pre_encryption_part(msg_enc=TRIPLE_DES_CBC, key_enc=RSA_1_5, key_name='my-rsa-key',
+def pre_encryption_part(msg_enc=TRIPLE_DES_CBC, key_enc=RSA_OAEP, 
+        key_name='my-rsa-key',
         encrypted_key_id=None, encrypted_data_id=None,
         encrypt_cert=None):
     """

--- a/src/saml2/xml_template/template.xml
+++ b/src/saml2/xml_template/template.xml
@@ -2,12 +2,10 @@
 <EncryptedData
         xmlns="http://www.w3.org/2001/04/xmlenc#"
         Type="http://www.w3.org/2001/04/xmlenc#Element">
-    <EncryptionMethod Algorithm=
-                              "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
+    <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
     <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
         <EncryptedKey xmlns="http://www.w3.org/2001/04/xmlenc#">
-            <EncryptionMethod Algorithm=
-                                      "http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+            <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
             <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
                 <KeyName/>
             </KeyInfo>

--- a/tests/test_42_enc.py
+++ b/tests/test_42_enc.py
@@ -12,7 +12,7 @@ from pathutils import full_path
 
 __author__ = 'roland'
 
-TMPL_NO_HEADER = """<ns0:EncryptedData xmlns:ns0="http://www.w3.org/2001/04/xmlenc#" xmlns:ns1="http://www.w3.org/2000/09/xmldsig#" Id="{ed_id}" Type="http://www.w3.org/2001/04/xmlenc#Element"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc" /><ns1:KeyInfo><ns0:EncryptedKey Id="{ek_id}"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5" /><ns1:KeyInfo><ns1:KeyName>my-rsa-key</ns1:KeyName></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedKey></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedData>"""
+TMPL_NO_HEADER = """<ns0:EncryptedData xmlns:ns0="http://www.w3.org/2001/04/xmlenc#" xmlns:ns1="http://www.w3.org/2000/09/xmldsig#" Id="{ed_id}" Type="http://www.w3.org/2001/04/xmlenc#Element"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc" /><ns1:KeyInfo><ns0:EncryptedKey Id="{ek_id}"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p" /><ns1:KeyInfo><ns1:KeyName>my-rsa-key</ns1:KeyName><ns1:X509Data><ns1:X509Certificate /></ns1:X509Data></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedKey></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedData>"""
 TMPL = "<?xml version='1.0' encoding='UTF-8'?>\n%s" % TMPL_NO_HEADER
 
 IDENTITY = {"eduPersonAffiliation": ["staff", "member"],


### PR DESCRIPTION
This PR achieved https://github.com/IdentityPython/pysaml2/pull/745

I have been forced for some time to disable assertion encryption due to an incompatibility issue between my pysaml2 based IdP and a Shibboleth SP, with this patch I got it to work.

It solved two weakness in pysaml2 encryption method, that ShibSP highlighted as follows

````
Fixed: "ERROR Shibboleth.SSO.SAML2 [6] [default]: failed to decrypt assertion: 
Unable to resolve any key decryption keys."
```` 
and also
````
WARN XMLTooling.Decrypter [7] [default]: XMLSecurity exception while decrypting key: 
XSECAlgorithmMapper::mapURIToHandler - URI http://www.w3.org/2001/04/xmlenc#rsa-1_5 
disallowed by whitelist/blacklist policy
````

Another warning about pysaml2 encryption with Shib SP is the follow:
 - saml2.server.create_authn_response have to disable `pefim`.

`encrypt_assertion`, `encrypt_advice_attributes`,  `encrypt_assertion_self_contained` works great instead.

Using PEFIM we'll have, shib SP side, this message
````
WARN Shibboleth.AttributeResolver.Query [4] [default]: no SAML 2 AttributeAuthority role found in metadata
````

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?