### PR TITLE
Handle all types of ACS endpoint specifications

### DIFF
--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -404,7 +404,12 @@ class Config(object):
         if endps and service in endps:
             for endpspec in endps[service]:
                 try:
-                    endp, bind = endpspec
+                    # endspec sometime is str, sometime is a tuple
+                    if type(endpspec) in (tuple, list):
+                        # slice prevents 3-tuple, eg: sp's assertion_consumer_service
+                        endp, bind = endpspec[0:2]
+                    else:
+                        endp, bind = endpspec
                     if binding is None or bind == binding:
                         spec.append(endp)
                 except ValueError:


### PR DESCRIPTION
With these changes a SP ACS service configured with a 3-tuple `(URL, binding, index)` works correctly.

Fixes #599


### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?