### PR TITLE
Fix StatusResponse when return_addrs is not set

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -255,7 +255,7 @@ class StatusResponse(object):
     def __init__(self, sec_context, return_addrs=None, timeslack=0,
             request_id=0, asynchop=True, conv_info=None):
         self.sec = sec_context
-        self.return_addrs = return_addrs
+        self.return_addrs = return_addrs or []
 
         self.timeslack = timeslack
         self.request_id = request_id
@@ -402,10 +402,11 @@ class StatusResponse(object):
                 raise RequestVersionTooHigh()
 
         if self.asynchop:
-            if self.response.destination and \
-                            self.response.destination not in self.return_addrs:
-                logger.error("%s not in %s", self.response.destination,
-                             self.return_addrs)
+            if (
+                self.response.destination
+                and self.response.destination not in self.return_addrs
+            ):
+                logger.error("%s not in %s", self.response.destination, self.return_addrs)
                 return None
 
         valid = self.issue_instant_ok() and self.status_ok()


### PR DESCRIPTION
Fix StatusResponse when return_addrs is not set

`return_addrs` is set to `None` by default in `StatusResponse.__init__()`.
If it is not filled with a proper value then `self._verify()` will fail because it tries
to iterate over a `None` object.

This PR avoids this error, by setting the `return_addrs` to `[]`.

```
if self.asynchop:
    if (
        self.response.destination
        and self.response.destination not in self.return_addrs
    ):
        logger.error("%s not in %s", self.response.destination, self.return_addrs)
        return None
```

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?