### PR TITLE
Minor bug fix to metadata function in example IdP

### DIFF
--- a/example/idp2/idp.py
+++ b/example/idp2/idp.py
@@ -1041,7 +1041,7 @@ def application(environ, start_response):
 
     path = environ.get("PATH_INFO", "").lstrip("/")
 
-    if path == "metadata":
+    if path == "idp.xml":
         return metadata(environ, start_response)
 
     kaka = environ.get("HTTP_COOKIE", None)

--- a/example/idp2/idp.py
+++ b/example/idp2/idp.py
@@ -999,7 +999,7 @@ def metadata(environ, start_response):
             args.sign,
         )
         start_response("200 OK", [("Content-Type", "text/xml")])
-        return metadata
+        return [metadata]
     except Exception as ex:
         logger.error("An error occured while creating metadata: %s", ex.message)
         return not_found(environ, start_response)


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?

Currently, you cannot access the metadata path with the example IdP. Trying to access it by going to the `/metadata` path yields an error: `ValueError: WSGI Applications must yield bytesI`. I saw from a [previous commit](https://github.com/IdentityPython/pysaml2/commit/f41f60ccd4700ea72104e9bab362be071fcb0e1b) to the example SP that the metadata needs to be returned as a list, so I made the same change here.

I also made another change that returns the metadata at `/idp.xml`. I feel like it is more suitable to make the entityID the same as the metadata path, but this change is not necessary.

I know these are small fixes, but I hope this will make the example IdP a little more usable for pysaml2 users. 