### PR TITLE
Invalid Destination URL Exception Handling

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -94,6 +94,9 @@ class StatusAuthnFailed(StatusError):
 class StatusInvalidAttrNameOrValue(StatusError):
     pass
 
+class StatusInvalidAuthnResponseStatement(StatusError):
+    pass
+
 
 class StatusInvalidNameidPolicy(StatusError):
     pass
@@ -1099,13 +1102,17 @@ class AuthnResponse(StatusResponse):
             return {"name_id": self.name_id, "came_from": self.came_from,
                     "issuer": self.issuer(), "not_on_or_after": nooa,
                     "authz_decision_info": self.authz_decision_info()}
-        else:
+        elif getattr(self.assertion, 'authn_statement', None):
             authn_statement = self.assertion.authn_statement[0]
             return {"ava": self.ava, "name_id": self.name_id,
                     "came_from": self.came_from, "issuer": self.issuer(),
                     "not_on_or_after": nooa, "authn_info": self.authn_info(),
                     "session_index": authn_statement.session_index}
-
+        else:
+            raise StatusInvalidAuthnResponseStatement(
+                "The Authn Response Statement is not valid"
+            )
+        
     def __str__(self):
         return self.xmlstr
 


### PR DESCRIPTION
If a SAML2 Response comes with a Destination different from the SP ACS URL, like the following:

````
<samlp:Response Destination="diversodaassertionconsumerserviceurl" 
                ID="_3afa266c-22ee-4bbc-8832-38b3d9b2f1c0" 
                InResponseTo="id-JmjyyMiU4yjezww0o" 
                IssueInstant="2021-01-23T23:54:47Z" 
                Version="2.0" 
                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" 
                xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
````

We have an exception in

````
env/lib/python3.8/site-packages/saml2/response.py", line 1103, in session_info
    authn_statement = self.assertion.authn_statement[0]
AttributeError: 'NoneType' object has no attribute 'authn_statement'
````

With this PR we handle this exception succesfully:

````
saml2/response.py", line 1112, in session_info
    raise StatusInvalidAuthnResponseStatement(
saml2.response.StatusInvalidAuthnResponseStatement: The Authn Response Statement is not valid
````

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



