### PR TITLE
Response with unvalued AudienceRestriction (Condition) Handling

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -209,10 +209,10 @@ def for_me(conditions, myself):
         if not restriction.audience:
             continue
         for audience in restriction.audience:
-            if audience.text.strip() == myself:
+            if audience.text and audience.text.strip() == myself:
                 return True
             else:
-                logger.debug("AudienceRestriction - One condition not satisfied: %s != %s" % (audience.text.strip(), myself))
+                logger.debug("AudienceRestriction - One condition not satisfied: {} != {}".format(audience.text, myself))
     logger.debug("AudienceRestrictions not satisfied!")
     return False
 


### PR DESCRIPTION
This PR prevents this exception

````
saml2/response.py", line 219, in for_me
    if audience.text.strip() == myself:
AttributeError: 'NoneType' object has no attribute 'strip'
````

When a SP get a Response with an unvalued AudienceRestriction (Condition) like this:

````
        <saml:Conditions NotBefore="2021-01-24T13:57:51Z" NotOnOrAfter="2021-01-24T14:02:44Z">
            <saml:AudienceRestriction>
                <saml:Audience/>
            </saml:AudienceRestriction>
        </saml:Conditions>
````

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



