### PR TITLE
specify minimum version needed for xmlschema

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     requests >= 1.0.0
     six
     importlib_resources
-    xmlschema
+    xmlschema >= 1.2.1
 
 
 [options.packages.find]


### PR DESCRIPTION
Sandbox mode was adding in 1.2.0 of python-xmlschema and refined in
1.2.1. Its use was added in 3b707723dcf1bf60677b424aac398c0c3557641d.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes? (It does not need a test.)
* [x] Does your submission pass tests? (No test will be affected.)
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter? (flake8 does not apply to this file.)



