### PR TITLE
[Strengthen Encryption] PySAML2 Encrypted Assertions now works with Shibboleth SP 3

### DIFF
--- a/src/saml2/data/templates/template_enc.xml
+++ b/src/saml2/data/templates/template_enc.xml
@@ -2,12 +2,10 @@
 <EncryptedData
         xmlns="http://www.w3.org/2001/04/xmlenc#"
         Type="http://www.w3.org/2001/04/xmlenc#Element">
-    <EncryptionMethod Algorithm=
-                              "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
+    <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
     <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
         <EncryptedKey xmlns="http://www.w3.org/2001/04/xmlenc#">
-            <EncryptionMethod Algorithm=
-                                      "http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+            <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
             <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
                 <KeyName/>
             </KeyInfo>

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -65,6 +65,7 @@ from saml2.sigver import security_context
 from saml2.sigver import SigverError
 from saml2.sigver import SignatureError
 from saml2.sigver import make_temp
+from saml2.sigver import get_pem_wrapped_unwrapped
 from saml2.sigver import pre_encryption_part
 from saml2.sigver import pre_signature_part
 from saml2.sigver import pre_encrypt_assertion
@@ -654,18 +655,22 @@ class Entity(HTTPBase):
             _certs = self.metadata.certs(sp_entity_id, "any", "encryption")
         exception = None
         for _cert in _certs:
+            wrapped_cert, unwrapped_cert = get_pem_wrapped_unwrapped(_cert)
             try:
-                begin_cert = "-----BEGIN CERTIFICATE-----\n"
-                end_cert = "\n-----END CERTIFICATE-----\n"
-                if begin_cert not in _cert:
-                    _cert = "%s%s" % (begin_cert, _cert)
-                if end_cert not in _cert:
-                    _cert = "%s%s" % (_cert, end_cert)
-                tmp = make_temp(_cert.encode('ascii'),
+                tmp = make_temp(wrapped_cert.encode('ascii'),
                                 decode=False,
                                 delete_tmpfiles=self.config.delete_tmpfiles)
+
+                # it would be possibile to handle many other args here ...
+                pre_enc_part_dict = dict()
+                if encrypt_cert:
+                    pre_enc_part_dict['encrypt_cert'] = unwrapped_cert
+                pre_enc_part = pre_encryption_part(**pre_enc_part_dict)
+                # end pre_enc_part
+
+
                 response = self.sec.encrypt_assertion(response, tmp.name,
-                                                      pre_encryption_part(),
+                                                      pre_enc_part,
                                                       node_xpath=node_xpath)
                 return response
             except Exception as ex:

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -657,21 +657,14 @@ class Entity(HTTPBase):
         for _cert in _certs:
             wrapped_cert, unwrapped_cert = get_pem_wrapped_unwrapped(_cert)
             try:
-                tmp = make_temp(wrapped_cert.encode('ascii'),
-                                decode=False,
-                                delete_tmpfiles=self.config.delete_tmpfiles)
-
-                # it would be possibile to handle many other args here ...
-                pre_enc_part_dict = dict()
-                if encrypt_cert:
-                    pre_enc_part_dict['encrypt_cert'] = unwrapped_cert
-                pre_enc_part = pre_encryption_part(**pre_enc_part_dict)
-                # end pre_enc_part
-
-
-                response = self.sec.encrypt_assertion(response, tmp.name,
-                                                      pre_enc_part,
-                                                      node_xpath=node_xpath)
+                tmp = make_temp(
+                    wrapped_cert.encode('ascii'),
+                    decode=False,
+                    delete_tmpfiles=self.config.delete_tmpfiles,
+                )
+                response = self.sec.encrypt_assertion(
+                    response, tmp.name, pre_encryption_part(), node_xpath=node_xpath
+                )
                 return response
             except Exception as ex:
                 exception = ex

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -663,7 +663,10 @@ class Entity(HTTPBase):
                     delete_tmpfiles=self.config.delete_tmpfiles,
                 )
                 response = self.sec.encrypt_assertion(
-                    response, tmp.name, pre_encryption_part(), node_xpath=node_xpath
+                    response,
+                    tmp.name,
+                    pre_encryption_part(encrypt_cert=unwrapped_cert),
+                    node_xpath=node_xpath,
                 )
                 return response
             except Exception as ex:

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -60,9 +60,8 @@ logger = logging.getLogger(__name__)
 
 SIG = '{{{ns}#}}{attribute}'.format(ns=ds.NAMESPACE, attribute='Signature')
 
-# DEPRECATED
-# RSA_1_5 = 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
-
+# RSA_1_5 is considered deprecated
+RSA_1_5 = 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
 TRIPLE_DES_CBC = 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'
 RSA_OAEP_MGF1P = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"
 

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -1844,6 +1844,7 @@ def pre_signature_part(
     if identifier:
         signature.id = 'Signature{n}'.format(n=identifier)
 
+    # XXX remove - do not embed the cert
     if public_key:
         x509_data = ds.X509Data(
             x509_certificate=[ds.X509Certificate(text=public_key)])
@@ -1881,10 +1882,13 @@ def pre_signature_part(
 # </EncryptedData>
 
 
-def pre_encryption_part(msg_enc=TRIPLE_DES_CBC, key_enc=RSA_OAEP_MGF1P, 
-        key_name='my-rsa-key',
-        encrypted_key_id=None, encrypted_data_id=None,
-        encrypt_cert=None):
+def pre_encryption_part(
+    msg_enc=TRIPLE_DES_CBC,
+    key_enc=RSA_OAEP_MGF1P,
+    key_name='my-rsa-key',
+    encrypted_key_id=None,
+    encrypted_data_id=None,
+):
     """
 
     :param msg_enc:
@@ -1896,12 +1900,8 @@ def pre_encryption_part(msg_enc=TRIPLE_DES_CBC, key_enc=RSA_OAEP_MGF1P,
     ed_id = encrypted_data_id or "ED_{id}".format(id=gen_random_key())
     msg_encryption_method = EncryptionMethod(algorithm=msg_enc)
     key_encryption_method = EncryptionMethod(algorithm=key_enc)
-    
-    enc_key_dict= dict(key_name=ds.KeyName(text=key_name))
-    enc_key_dict['x509_data'] = ds.X509Data(
-        x509_certificate=ds.X509Certificate(text=encrypt_cert))
-    key_info = ds.KeyInfo(**enc_key_dict)
-    
+    key_info = ds.KeyInfo(key_name=ds.KeyName(text=key_name))
+
     encrypted_key = EncryptedKey(
         id=ek_id,
         encryption_method=key_encryption_method,
@@ -1914,7 +1914,8 @@ def pre_encryption_part(msg_enc=TRIPLE_DES_CBC, key_enc=RSA_OAEP_MGF1P,
         type='http://www.w3.org/2001/04/xmlenc#Element',
         encryption_method=msg_encryption_method,
         key_info=key_info,
-        cipher_data=CipherData(cipher_value=CipherValue(text='')))
+        cipher_data=CipherData(cipher_value=CipherValue(text='')),
+    )
     return encrypted_data
 
 

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -1882,24 +1882,28 @@ def pre_signature_part(
 
 
 def pre_encryption_part(
+    *,
     msg_enc=TRIPLE_DES_CBC,
     key_enc=RSA_OAEP_MGF1P,
     key_name='my-rsa-key',
     encrypted_key_id=None,
     encrypted_data_id=None,
+    encrypt_cert=None,
 ):
-    """
-
-    :param msg_enc:
-    :param key_enc:
-    :param key_name:
-    :return:
-    """
     ek_id = encrypted_key_id or "EK_{id}".format(id=gen_random_key())
     ed_id = encrypted_data_id or "ED_{id}".format(id=gen_random_key())
     msg_encryption_method = EncryptionMethod(algorithm=msg_enc)
     key_encryption_method = EncryptionMethod(algorithm=key_enc)
-    key_info = ds.KeyInfo(key_name=ds.KeyName(text=key_name))
+
+    x509_data = (
+        ds.X509Data(x509_certificate=ds.X509Certificate(text=encrypt_cert))
+        if encrypt_cert
+        else None
+    )
+    key_info = ds.KeyInfo(
+        key_name=ds.KeyName(text=key_name),
+        x509_data=x509_data,
+    )
 
     encrypted_key = EncryptedKey(
         id=ek_id,

--- a/tests/test_42_enc.py
+++ b/tests/test_42_enc.py
@@ -12,7 +12,7 @@ from pathutils import full_path
 
 __author__ = 'roland'
 
-TMPL_NO_HEADER = """<ns0:EncryptedData xmlns:ns0="http://www.w3.org/2001/04/xmlenc#" xmlns:ns1="http://www.w3.org/2000/09/xmldsig#" Id="{ed_id}" Type="http://www.w3.org/2001/04/xmlenc#Element"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc" /><ns1:KeyInfo><ns0:EncryptedKey Id="{ek_id}"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p" /><ns1:KeyInfo><ns1:KeyName>my-rsa-key</ns1:KeyName><ns1:X509Data><ns1:X509Certificate /></ns1:X509Data></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedKey></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedData>"""
+TMPL_NO_HEADER = """<ns0:EncryptedData xmlns:ns0="http://www.w3.org/2001/04/xmlenc#" xmlns:ns1="http://www.w3.org/2000/09/xmldsig#" Id="{ed_id}" Type="http://www.w3.org/2001/04/xmlenc#Element"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc" /><ns1:KeyInfo><ns0:EncryptedKey Id="{ek_id}"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p" /><ns1:KeyInfo><ns1:KeyName>my-rsa-key</ns1:KeyName></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedKey></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedData>"""
 TMPL = f"<?xml version='1.0' encoding='UTF-8'?>\n{TMPL_NO_HEADER}"
 
 IDENTITY = {"eduPersonAffiliation": ["staff", "member"],

--- a/tests/test_42_enc.py
+++ b/tests/test_42_enc.py
@@ -12,8 +12,8 @@ from pathutils import full_path
 
 __author__ = 'roland'
 
-TMPL_NO_HEADER = """<ns0:EncryptedData xmlns:ns0="http://www.w3.org/2001/04/xmlenc#" xmlns:ns1="http://www.w3.org/2000/09/xmldsig#" Id="{ed_id}" Type="http://www.w3.org/2001/04/xmlenc#Element"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc" /><ns1:KeyInfo><ns0:EncryptedKey Id="{ek_id}"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5" /><ns1:KeyInfo><ns1:KeyName>my-rsa-key</ns1:KeyName></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedKey></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedData>"""
-TMPL = "<?xml version='1.0' encoding='UTF-8'?>\n%s" % TMPL_NO_HEADER
+TMPL_NO_HEADER = """<ns0:EncryptedData xmlns:ns0="http://www.w3.org/2001/04/xmlenc#" xmlns:ns1="http://www.w3.org/2000/09/xmldsig#" Id="{ed_id}" Type="http://www.w3.org/2001/04/xmlenc#Element"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc" /><ns1:KeyInfo><ns0:EncryptedKey Id="{ek_id}"><ns0:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p" /><ns1:KeyInfo><ns1:KeyName>my-rsa-key</ns1:KeyName><ns1:X509Data><ns1:X509Certificate /></ns1:X509Data></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedKey></ns1:KeyInfo><ns0:CipherData><ns0:CipherValue /></ns0:CipherData></ns0:EncryptedData>"""
+TMPL = f"<?xml version='1.0' encoding='UTF-8'?>\n{TMPL_NO_HEADER}"
 
 IDENTITY = {"eduPersonAffiliation": ["staff", "member"],
             "surName": ["Jeter"], "givenName": ["Derek"],


### PR DESCRIPTION
This PR achieved https://github.com/IdentityPython/pysaml2/pull/745

I have been forced for some time to disable assertion encryption due to an incompatibility issue between my pysaml2 based IdP and a Shibboleth SP, with this patch I got it to work.

It solved two weakness in pysaml2 encryption method, that ShibSP highlighted as follows

````
Fixed: "ERROR Shibboleth.SSO.SAML2 [6] [default]: failed to decrypt assertion: 
Unable to resolve any key decryption keys."
```` 
and also
````
WARN XMLTooling.Decrypter [7] [default]: XMLSecurity exception while decrypting key: 
XSECAlgorithmMapper::mapURIToHandler - URI http://www.w3.org/2001/04/xmlenc#rsa-1_5 
disallowed by whitelist/blacklist policy
````

Another warning about pysaml2 encryption with Shib SP is the follow:
 - saml2.server.create_authn_response have to disable `pefim`.

`encrypt_assertion`, `encrypt_advice_attributes`,  `encrypt_assertion_self_contained` works great instead.

Using PEFIM we'll have, shib SP side, this message
````
WARN Shibboleth.AttributeResolver.Query [4] [default]: no SAML 2 AttributeAuthority role found in metadata
````

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



