### PR TITLE
Raise SAMLError on failure to parse a metadata file

### DIFF
--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -15,6 +15,7 @@ from os.path import join
 import requests
 import six
 
+from xml.etree.ElementTree import ParseError
 from saml2 import md
 from saml2 import saml
 from saml2 import samlp
@@ -612,8 +613,12 @@ class InMemoryMetaData(MetaData):
             self.entity[entity_descr.entity_id] = _ent
 
     def parse(self, xmlstr):
-        self.entities_descr = md.entities_descriptor_from_string(xmlstr)
-
+        try:
+            self.entities_descr = md.entities_descriptor_from_string(xmlstr)
+        except Exception as e:
+            logger.error(f'Metadata Parse Error on: {self.filename}')
+            return
+        
         if not self.entities_descr:
             self.entity_descr = md.entity_descriptor_from_string(xmlstr)
             if self.entity_descr:

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -7,15 +7,14 @@ import os
 import sys
 from itertools import chain
 from warnings import warn as _warn
-
 from hashlib import sha1
 from os.path import isfile
 from os.path import join
 
 import requests
+
 import six
 
-from xml.etree.ElementTree import ParseError
 from saml2 import md
 from saml2 import saml
 from saml2 import samlp
@@ -25,7 +24,6 @@ from saml2 import SAMLError
 from saml2 import BINDING_HTTP_REDIRECT
 from saml2 import BINDING_HTTP_POST
 from saml2 import BINDING_SOAP
-
 from saml2.httpbase import HTTPBase
 from saml2.extension.idpdisc import BINDING_DISCO
 from saml2.extension.idpdisc import DiscoveryResponse
@@ -616,9 +614,8 @@ class InMemoryMetaData(MetaData):
         try:
             self.entities_descr = md.entities_descriptor_from_string(xmlstr)
         except Exception as e:
-            logger.error(f'Metadata Parse Error on: {self.filename}')
-            return
-        
+            raise SAMLError(f'Failed to parse metadata file: {self.filename}') from e
+
         if not self.entities_descr:
             self.entity_descr = md.entity_descriptor_from_string(xmlstr)
             if self.entity_descr:

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -832,7 +832,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
             '--privkey-pem', key_file,
             '--id-attr:ID', node_name,
         ]
-        
+
         if node_id:
             com_list.extend(['--node-id', node_id])
 
@@ -952,6 +952,7 @@ class CryptoBackendXMLSecurity(CryptoBackend):
         """
         import xmlsec
         import lxml.etree
+
         xml = xmlsec.parse_xml(statement)
         signed = xmlsec.sign(xml, key_file)
         signed_str = lxml.etree.tostring(signed, xml_declaration=False, encoding="UTF-8")

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -832,7 +832,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
             '--privkey-pem', key_file,
             '--id-attr:ID', node_name,
         ]
-
+        
         if node_id:
             com_list.extend(['--node-id', node_id])
 
@@ -952,7 +952,6 @@ class CryptoBackendXMLSecurity(CryptoBackend):
         """
         import xmlsec
         import lxml.etree
-
         xml = xmlsec.parse_xml(statement)
         signed = xmlsec.sign(xml, key_file)
         signed_str = lxml.etree.tostring(signed, xml_declaration=False, encoding="UTF-8")

--- a/tests/invalid_metadata_file.xml
+++ b/tests/invalid_metadata_file.xml
@@ -1,0 +1,1 @@
+this content is invalid

--- a/tests/test_30_mdstore.py
+++ b/tests/test_30_mdstore.py
@@ -7,6 +7,8 @@ from collections import OrderedDict
 from unittest.mock import Mock
 from unittest.mock import patch
 
+from pytest import raises
+
 import responses
 
 from six.moves.urllib import parse
@@ -19,6 +21,7 @@ from saml2.mdstore import locations
 from saml2.mdstore import name
 from saml2 import sigver
 from saml2.httpbase import HTTPBase
+from saml2 import SAMLError
 from saml2 import BINDING_SOAP
 from saml2 import BINDING_HTTP_REDIRECT
 from saml2 import BINDING_HTTP_POST
@@ -156,6 +159,10 @@ METADATACONF = {
         "class": "saml2.mdstore.MetaDataFile",
         "metadata": [(full_path("swamid-2.0.xml"),)],
     }],
+    "14": [{
+        "class": "saml2.mdstore.MetaDataFile",
+        "metadata": [(full_path("invalid_metadata_file.xml"),)],
+    }],
 }
 
 
@@ -168,6 +175,12 @@ def _fix_valid_until(xmlstring):
     new_date = new_date.strftime("%Y-%m-%dT%H:%M:%SZ")
     return re.sub(r' validUntil=".*?"', ' validUntil="%s"' % new_date,
                   xmlstring)
+
+
+def test_invalid_metadata():
+    mds = MetadataStore(ATTRCONV, sec_config, disable_ssl_certificate_validation=True)
+    with raises(SAMLError):
+        mds.imp(METADATACONF["14"])
 
 
 def test_swami_1():


### PR DESCRIPTION
This Pull Request prevents that a faulty Metadata file will cause a general service failure.
As we can as follows, I put a markdown file in the metadata folder, with this Patch the problem doesn't cause any system fault, just an error will be printed in the logs
````
Metadata Parse Error on: /home/wert/DEV/IdentityPython/Django-Identity/djangosaml2_sp/saml2_sp/saml2_config/test.md
````

Otherwise a Http Error 500 will be shown and also in the logs something like this:

````
  File "/home/wert/DEV/IdentityPython/env/lib/python3.8/site-packages/saml2/config.py", line 337, in load
    self.load_complex(cnf)
  File "/home/wert/DEV/IdentityPython/env/lib/python3.8/site-packages/saml2/config.py", line 271, in load_complex
    self.setattr("", "metadata", self.load_metadata(cnf["metadata"]))
  File "/home/wert/DEV/IdentityPython/env/lib/python3.8/site-packages/saml2/config.py", line 387, in load_metadata
    mds.imp(metadata_conf)
  File "/home/wert/DEV/IdentityPython/env/lib/python3.8/site-packages/saml2/mdstore.py", line 1077, in imp
    self.load(key, val)
  File "/home/wert/DEV/IdentityPython/env/lib/python3.8/site-packages/saml2/mdstore.py", line 1014, in load
    _md.load()
  File "/home/wert/DEV/IdentityPython/env/lib/python3.8/site-packages/saml2/mdstore.py", line 765, in load
    return self.parse_and_check_signature(_txt)
  File "/home/wert/DEV/IdentityPython/env/lib/python3.8/site-packages/saml2/mdstore.py", line 728, in parse_and_check_signature
    self.parse(txt)
  File "/home/wert/DEV/IdentityPython/env/lib/python3.8/site-packages/saml2/mdstore.py", line 615, in parse
    self.entities_descr = md.entities_descriptor_from_string(xmlstr)
  File "/home/wert/DEV/IdentityPython/env/lib/python3.8/site-packages/saml2/md.py", line 1859, in entities_descriptor_from_string
    return saml2.create_class_from_xml_string(EntitiesDescriptor, xml_string)
  File "/home/wert/DEV/IdentityPython/env/lib/python3.8/site-packages/saml2/__init__.py", line 92, in create_class_from_xml_string
    tree = defusedxml.ElementTree.fromstring(xml_string)
  File "/home/wert/DEV/IdentityPython/env/lib/python3.8/site-packages/defusedxml/common.py", line 132, in fromstring
    return parser.close()
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 1702, in close
    self._raiseerror(v)
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 1602, in _raiseerror
    raise err
  File "<string>", line None
xml.etree.ElementTree.ParseError: no element found: line 1, column 0
```` 

I'd like to handle `xml.etree.ElementTree.ParseError` properly but xml.etree's exceptions are quite heavy ...


### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



