### PR TITLE
Validate Destination

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -409,12 +409,9 @@ class StatusResponse(object):
                 raise RequestVersionTooHigh()
 
         destination = self.response.destination
-        if self.asynchop:
+        if self.asynchop and destination:
             # Destination must be present
-            if (
-                not destination
-                or destination not in self.return_addrs
-            ):
+            if destination not in self.return_addrs:
                 logger.error(
                     f"{destination} not in {self.return_addrs}"
                 )

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -408,12 +408,16 @@ class StatusResponse(object):
             else:
                 raise RequestVersionTooHigh()
 
+        destination = self.response.destination
         if self.asynchop:
+            # Destination must be present
             if (
-                self.response.destination
-                and self.response.destination not in self.return_addrs
+                not destination
+                or destination not in self.return_addrs
             ):
-                logger.error("%s not in %s", self.response.destination, self.return_addrs)
+                logger.error(
+                    f"{destination} not in {self.return_addrs}"
+                )
                 return None
 
         valid = self.issue_instant_ok() and self.status_ok()
@@ -1116,7 +1120,7 @@ class AuthnResponse(StatusResponse):
             raise StatusInvalidAuthnResponseStatement(
                 "The Authn Response Statement is not valid"
             )
-        
+
     def __str__(self):
         return self.xmlstr
 


### PR DESCRIPTION
This PR introduces a validation on the Destination attribute value, in Response.
Destination value MUST be present if binding is HTTP-REDIRECT or HTTP-POST, and correctly valued

fixes: https://github.com/IdentityPython/pysaml2/issues/770

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



