### PR TITLE
Fix IssueInstant validation

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -1044,7 +1044,7 @@ class AuthnResponse(StatusResponse):
             logger.error("Verification error on the response: %s", err)
             raise
         else:
-            if res is None:
+            if not res:
                 return None
 
         if not isinstance(self.response, samlp.Response):


### PR DESCRIPTION
This PR fixes the validation of issue instant in a way that a response like the following can't be intended as valid anymore

````
<samlp:Response xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Destination="http://localhost:8000/spid/acs/" ID="_riihjyee-qemu-pfpj-zdlr-fjizpqrjctug" InResponseTo="id-oi0QyNpBmSwd2S8Jh" 

IssueInstant="2018-01-01T00:00:00Z" 

Version="2.0">
````

this PR fixes https://github.com/IdentityPython/pysaml2/issues/767

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



