### PR TITLE
Response issuer can be None

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -1121,7 +1121,7 @@ class AuthnResponse(StatusResponse):
             raise StatusInvalidAuthnResponseStatement(
                 "The Authn Response Statement is not valid"
             )
-        
+
     def __str__(self):
         return self.xmlstr
 

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -435,7 +435,10 @@ class StatusResponse(object):
         self.response = mold.response
 
     def issuer(self):
-        return self.response.issuer.text.strip()
+        if self.response.issuer is None:
+            return ""
+        else:
+            return self.response.issuer.text.strip()
 
 
 class LogoutResponse(StatusResponse):

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -435,10 +435,12 @@ class StatusResponse(object):
         self.response = mold.response
 
     def issuer(self):
-        if self.response.issuer is None:
-            return ""
-        else:
-            return self.response.issuer.text.strip()
+        issuer_value = (
+            self.response.issuer.text
+            if self.response.issuer is not None
+            else ""
+        ).strip()
+        return issuer_value
 
 
 class LogoutResponse(StatusResponse):

--- a/tests/test_41_response.py
+++ b/tests/test_41_response.py
@@ -71,6 +71,16 @@ class TestResponse:
                 name_id=name_id,
                 authn=AUTHN)
 
+            self._resp_issuer_none = server.create_authn_response(
+                IDENTITY,
+                "id12",  # in_response_to
+                "http://lingon.catalogix.se:8087/",
+                # consumer_url
+                "urn:mace:example.com:saml:roland:sp",
+                # sp_entity_id
+                name_id=name_id)
+            self._resp_issuer_none.issuer = None
+
             conf = config.SPConfig()
             conf.load_file("server_conf")
             self.conf = conf
@@ -98,6 +108,19 @@ class TestResponse:
 
         assert isinstance(resp, StatusResponse)
         assert isinstance(resp, AuthnResponse)
+
+    def test_issuer_none(self):
+        xml_response = ("%s" % (self._resp_issuer_none,))
+        resp = response_factory(xml_response, self.conf,
+                                return_addrs=[
+                                    "http://lingon.catalogix.se:8087/"],
+                                outstanding_queries={
+                                    "id12": "http://localhost:8088/sso"},
+                                timeslack=TIMESLACK, decode=False)
+
+        assert isinstance(resp, StatusResponse)
+        assert isinstance(resp, AuthnResponse)
+        assert resp.issuer() == ""
 
     @mock.patch('saml2.time_util.datetime')
     def test_false_sign(self, mock_datetime):

--- a/tests/test_41_response.py
+++ b/tests/test_41_response.py
@@ -48,37 +48,37 @@ class TestResponse:
 
             self._resp_ = server.create_authn_response(
                 IDENTITY,
-                "id12",  # in_response_to
-                "http://lingon.catalogix.se:8087/",
-                # consumer_url
-                "urn:mace:example.com:saml:roland:sp",
-                # sp_entity_id
-                name_id=name_id)
+                in_response_to="id12",
+                destination="http://lingon.catalogix.se:8087/",
+                sp_entity_id="urn:mace:example.com:saml:roland:sp",
+                name_id=name_id,
+            )
 
             self._sign_resp_ = server.create_authn_response(
                 IDENTITY,
-                "id12",  # in_response_to
-                "http://lingon.catalogix.se:8087/",  # consumer_url
-                "urn:mace:example.com:saml:roland:sp",  # sp_entity_id
+                in_response_to="id12",
+                destination="http://lingon.catalogix.se:8087/",
+                sp_entity_id="urn:mace:example.com:saml:roland:sp",
                 name_id=name_id,
-                sign_assertion=True)
+                sign_assertion=True,
+            )
 
             self._resp_authn = server.create_authn_response(
                 IDENTITY,
-                "id12",  # in_response_to
-                "http://lingon.catalogix.se:8087/",  # consumer_url
-                "urn:mace:example.com:saml:roland:sp",  # sp_entity_id
+                in_response_to="id12",
+                destination="http://lingon.catalogix.se:8087/",
+                sp_entity_id="urn:mace:example.com:saml:roland:sp",
                 name_id=name_id,
-                authn=AUTHN)
+                authn=AUTHN,
+            )
 
             self._resp_issuer_none = server.create_authn_response(
                 IDENTITY,
-                "id12",  # in_response_to
-                "http://lingon.catalogix.se:8087/",
-                # consumer_url
-                "urn:mace:example.com:saml:roland:sp",
-                # sp_entity_id
-                name_id=name_id)
+                in_response_to="id12",
+                destination="http://lingon.catalogix.se:8087/",
+                sp_entity_id="urn:mace:example.com:saml:roland:sp",
+                name_id=name_id,
+            )
             self._resp_issuer_none.issuer = None
 
             conf = config.SPConfig()
@@ -87,36 +87,41 @@ class TestResponse:
 
     def test_1(self):
         xml_response = ("%s" % (self._resp_,))
-        resp = response_factory(xml_response, self.conf,
-                                return_addrs=[
-                                    "http://lingon.catalogix.se:8087/"],
-                                outstanding_queries={
-                                    "id12": "http://localhost:8088/sso"},
-                                timeslack=TIMESLACK, decode=False)
+        resp = response_factory(
+            xml_response, self.conf,
+            return_addrs=["http://lingon.catalogix.se:8087/"],
+            outstanding_queries={"id12": "http://localhost:8088/sso"},
+            timeslack=TIMESLACK,
+            decode=False,
+        )
 
         assert isinstance(resp, StatusResponse)
         assert isinstance(resp, AuthnResponse)
 
     def test_2(self):
         xml_response = self._sign_resp_
-        resp = response_factory(xml_response, self.conf,
-                                return_addrs=[
-                                    "http://lingon.catalogix.se:8087/"],
-                                outstanding_queries={
-                                    "id12": "http://localhost:8088/sso"},
-                                timeslack=TIMESLACK, decode=False)
+        resp = response_factory(
+            xml_response,
+            self.conf,
+            return_addrs=["http://lingon.catalogix.se:8087/"],
+            outstanding_queries={"id12": "http://localhost:8088/sso"},
+            timeslack=TIMESLACK,
+            decode=False,
+        )
 
         assert isinstance(resp, StatusResponse)
         assert isinstance(resp, AuthnResponse)
 
     def test_issuer_none(self):
         xml_response = ("%s" % (self._resp_issuer_none,))
-        resp = response_factory(xml_response, self.conf,
-                                return_addrs=[
-                                    "http://lingon.catalogix.se:8087/"],
-                                outstanding_queries={
-                                    "id12": "http://localhost:8088/sso"},
-                                timeslack=TIMESLACK, decode=False)
+        resp = response_factory(
+            xml_response,
+            self.conf,
+            return_addrs=["http://lingon.catalogix.se:8087/"],
+            outstanding_queries={"id12": "http://localhost:8088/sso"},
+            timeslack=TIMESLACK,
+            decode=False,
+        )
 
         assert isinstance(resp, StatusResponse)
         assert isinstance(resp, AuthnResponse)


### PR DESCRIPTION
Per the SAML spec the `Issuer` element in a `Response` is optional.
Return an empty string (`""`) when the response issuer is not defined (`None`),
instead of trying to retrieve the text attribute and crashing.

Fixes #800 

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?