### PR TITLE
Update Travis CI badge from travis-ci.org -> travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ PySAML2 - SAML2 in Python
 :Version: see VERSION_
 :Documentation: https://pysaml2.readthedocs.io/
 
-.. image:: https://api.travis-ci.org/IdentityPython/pysaml2.png?branch=master
-    :target: https://travis-ci.org/IdentityPython/pysaml2
+.. image:: https://api.travis-ci.com/IdentityPython/pysaml2.png?branch=master
+    :target: https://travis-ci.com/IdentityPython/pysaml2
 
 .. image:: https://img.shields.io/pypi/pyversions/pysaml2.svg
     :target: https://pypi.org/project/pysaml2/


### PR DESCRIPTION
travis-ci.org is shutting down in several weeks, with all accounts migrating to travis-ci.com.
This repository was already migrated to travis-ci.com, so update the badge to reflect that.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes? **N/A**
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter? **N/A**



