### PR TITLE
Support metadata reload (plus minor fixes)

### DIFF
--- a/src/saml2/assertion.py
+++ b/src/saml2/assertion.py
@@ -35,6 +35,9 @@ def _filter_values(vals, vlist=None, must=False):
     if not vlist:  # No value specified equals any value
         return vals
 
+    if vals is None: # cannot iterate over None, return early
+        return vals
+
     if isinstance(vlist, six.string_types):
         vlist = [vlist]
 

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -203,6 +203,40 @@ class Entity(HTTPBase):
 
         self.msg_cb = msg_cb
 
+    def reload_metadata(self, metadata_conf):
+        """
+        Reload metadata configuration.
+
+	Load a new metadata configuration as defined by metadata_conf (by
+        passing this to Config.load_metadata) and make this entity (as well as
+        subordinate objects with own metadata reference) use the new metadata.
+
+        The structure of metadata_conf is the same as the 'metadata' entry in
+        the configuration passed to saml2.Config.
+
+        param metadata_conf: Metadata configuration as passed to Config.load_metadata
+        return: True if successfully reloaded
+        """
+        logger.debug("Loading new metadata")
+        try:
+            new_metadata = self.config.load_metadata(metadata_conf)
+        except Exception as ex:
+            logger.error("Loading metadata failed", exc_info=ex)
+            return False
+
+        logger.debug("Applying new metadata to main config")
+        ( self.metadata, self.sec.metadata, self.config.metadata ) = [new_metadata]*3
+        for typ in ["aa", "idp", "sp", "pdp", "aq"]:
+            policy = getattr(self.config, "_%s_policy" % typ, None)
+            if policy and policy.metadata_store:
+                logger.debug("Applying new metadata to %s policy", typ)
+                policy.metadata_store = self.metadata
+
+        logger.debug("Applying new metadata source_id")
+        self.sourceid = self.metadata.construct_source_id()
+
+        return True
+
     def _issuer(self, entityid=None):
         """ Return an Issuer instance """
         if entityid:

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -226,11 +226,10 @@ class Entity(HTTPBase):
 
         logger.debug("Applying new metadata to main config")
         ( self.metadata, self.sec.metadata, self.config.metadata ) = [new_metadata]*3
-        for typ in ["aa", "idp", "sp", "pdp", "aq"]:
-            policy = getattr(self.config, "_%s_policy" % typ, None)
-            if policy and policy.metadata_store:
-                logger.debug("Applying new metadata to %s policy", typ)
-                policy.metadata_store = self.metadata
+        policy = getattr(self.config, "_%s_policy" % self.entity_type, None)
+        if policy and policy.metadata_store:
+            logger.debug("Applying new metadata to %s policy", self.entity_type)
+            policy.metadata_store = self.metadata
 
         logger.debug("Applying new metadata source_id")
         self.sourceid = self.metadata.construct_source_id()

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -207,7 +207,7 @@ class Entity(HTTPBase):
         """
         Reload metadata configuration.
 
-	Load a new metadata configuration as defined by metadata_conf (by
+        Load a new metadata configuration as defined by metadata_conf (by
         passing this to Config.load_metadata) and make this entity (as well as
         subordinate objects with own metadata reference) use the new metadata.
 

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -618,7 +618,10 @@ class InMemoryMetaData(MetaData):
         try:
             self.entities_descr = md.entities_descriptor_from_string(xmlstr)
         except Exception as e:
-            raise SAMLError(f'Failed to parse metadata file: {self.filename}') from e
+            _md_desc = (f'metadata file: {self.filename}' if isinstance(self,MetaDataFile) else
+                       f'remote metadata: {self.url}' if isinstance(self, MetaDataExtern) else
+                       'metadata')
+            raise SAMLError(f'Failed to parse {_md_desc}') from e
 
         if not self.entities_descr:
             self.entity_descr = md.entity_descriptor_from_string(xmlstr)

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -618,9 +618,13 @@ class InMemoryMetaData(MetaData):
         try:
             self.entities_descr = md.entities_descriptor_from_string(xmlstr)
         except Exception as e:
-            _md_desc = (f'metadata file: {self.filename}' if isinstance(self,MetaDataFile) else
-                       f'remote metadata: {self.url}' if isinstance(self, MetaDataExtern) else
-                       'metadata')
+            _md_desc = (
+                f'metadata file: {self.filename}'
+                if isinstance(self,MetaDataFile)
+                else f'remote metadata: {self.url}'
+                if isinstance(self, MetaDataExtern)
+                else 'metadata'
+            )
             raise SAMLError(f'Failed to parse {_md_desc}') from e
 
         if not self.entities_descr:

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -1693,4 +1693,5 @@ class MetadataStore(MetaData):
 
             return "%s" % res
         elif format == "md":
-            return json.dumps(self.items(), indent=2)
+            # self.items() returns dictitems(), convert that back into a dict
+            return json.dumps(dict(self.items()), indent=2)

--- a/src/saml2/time_util.py
+++ b/src/saml2/time_util.py
@@ -269,7 +269,7 @@ def utc_now():
 
 
 def before(point):
-    """ True if point datetime specification is before now.
+    """ True if current time is before point datetime specification.
 
     NOTE: If point is specified it is supposed to be in local time.
     Not UTC/GMT !! This is because that is what gmtime() expects.
@@ -286,7 +286,7 @@ def before(point):
 
 
 def after(point):
-    """ True if point datetime specification is equal or after now """
+    """ True if current time is after or equal to point datetime specification."""
     if not point:
         return True
     else:


### PR DESCRIPTION
### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [Not yet] Have you written new tests for your changes?
* [N/A] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?

Hi,

As discussed in #808 , this adds support for metadata refresh by adding a `metadata_reload` method into `saml2.Entity`.

This method is to be externally invoked, and to receive the same metadata configuration as what was passed under the `metadata` key to `saml2.Config`.  The method loads a new metadata configuration and swaps it in (replacing the references across several objects that hold a metadata reference).

There will be an accompanying Pull Request for SATOSA using this functionality.

Cheers,
Vlad

PS: This PR also includes a few minor fixes done along the way...