### PR TITLE
Destination value MUST be present in Response if binding is HTTP-REDIRECT or HTTP-POST

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -409,11 +409,17 @@ class StatusResponse(object):
                 raise RequestVersionTooHigh()
 
         if self.asynchop:
-            if (
-                self.response.destination
-                and self.response.destination not in self.return_addrs
+            if not (
+                 getattr(self.response, 'destination')
             ):
-                logger.error("%s not in %s", self.response.destination, self.return_addrs)
+                logger.error(
+                    f"Invalid response destination in asynchop"
+                )
+                return None
+            elif self.response.destination not in self.return_addrs:
+                logger.error(
+                    f"{self.response.destination} not in {self.return_addrs}"
+                )
                 return None
 
         valid = self.issue_instant_ok() and self.status_ok()

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -409,11 +409,9 @@ class StatusResponse(object):
                 raise RequestVersionTooHigh()
 
         if self.asynchop:
-            if not (
-                 getattr(self.response, 'destination')
-            ):
+            if not getattr(self.response, 'destination', None):
                 logger.error(
-                    f"Invalid response destination in asynchop"
+                    "Invalid response destination in asynchop"
                 )
                 return None
             elif self.response.destination not in self.return_addrs:


### PR DESCRIPTION
A general review of https://github.com/IdentityPython/pysaml2/pull/782

Destination MAY be omitted, because it's optional, BUT if present it MUST be validated upon a match on valid ones.

Destination MUST be present if the SAML Binding is async (HTTP-POST or HTTP-REDIRECT).

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



