### PR TITLE
More specific SignatureErrors when validating

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -1491,7 +1491,7 @@ class SecurityContext(object):
             _schema.validate(str(item))
         except XMLSchemaError as e:
             error_context = {
-                "message": "Signature verification failed. Invalid document format.",
+                "message": "Signature verification failed. Invalid document format: {}".format(str(e)),
                 "ID": item.id,
                 "issuer": _issuer,
                 "type": node_name,


### PR DESCRIPTION
Provides more detail on why a schema validation has failed during signature checks.

When a signature check fails due to the XML document not passing validation against several schemata, it merely yields the message "Signature verification failed. Invalid document format."  When working with pysaml2 I found this message to be misleading due to the fact that I would expect a cryptography problem to be the error when this particular piece of code seems to be concerned with the correctness of the signatures. Only after reading `sigver.py` I became aware that there's an actual schema validation taking place at that point and this causes my error.
The generation of the SignatureError in its current state completely strips any information about what is actually wrong from the original XMLSchemaError and replaces it with a rather noninformative generic message.
This PR fixes that by incorporating the XMLSchemaErrors message into the SignatureError's message.





