### PR TITLE
Keep unknown metadata extensions

### DIFF
--- a/src/saml2/__init__.py
+++ b/src/saml2/__init__.py
@@ -981,7 +981,7 @@ def extension_element_to_element(extension_element, translation_functions,
     return None
 
 
-def extension_elements_to_elements(extension_elements, schemas):
+def extension_elements_to_elements(extension_elements, schemas, keep_unmatched=False):
     """ Create a list of elements each one matching one of the
     given extension elements. This is of course dependent on the access
     to schemas that describe the extension elements.
@@ -989,6 +989,8 @@ def extension_elements_to_elements(extension_elements, schemas):
     :param extension_elements: The list of extension elements
     :param schemas: Imported Python modules that represent the different
         known schemas used for the extension elements
+    :param keep_unmatched: Whether to keep extension elements that did not match any
+        schemas
     :return: A list of elements, representing the set of extension elements
         that was possible to match against a Class in the given schemas.
         The elements returned are the native representation of the elements
@@ -1004,13 +1006,19 @@ def extension_elements_to_elements(extension_elements, schemas):
         return res
 
     for extension_element in extension_elements:
-        for schema in schemas:
-            inst = extension_element_to_element(extension_element,
-                                                schema.ELEMENT_FROM_STRING,
-                                                schema.NAMESPACE)
-            if inst:
-                res.append(inst)
-                break
+        convert_results = (
+            inst
+            for schema in schemas
+            for inst in [
+                extension_element_to_element(
+                    extension_element, schema.ELEMENT_FROM_STRING, schema.NAMESPACE
+                )
+            ]
+            if inst
+        )
+        result = next(convert_results, extension_element if keep_unmatched else None)
+        if result:
+            res.append(result)
 
     return res
 


### PR DESCRIPTION
The `saml2.mdstore.MetadataStore` object removes any `Extension` elements it cannot convert to SAML elements.

With this changeset, unknown `Extension` elements are kept and serialized, in order for users to be able to look those up.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?