### PR TITLE
Handle KeyError when retrieving SessionIndex

### DIFF
--- a/src/saml2/client.py
+++ b/src/saml2/client.py
@@ -294,9 +294,12 @@ class Saml2Client(Base):
                 )
                 continue
 
-            session_info = self.users.get_info_from(name_id, entity_id, False)
-            session_index = session_info.get('session_index')
-            session_indexes = [session_index] if session_index else None
+            try:
+                session_info = self.users.get_info_from(name_id, entity_id, False)
+                session_index = session_info.get('session_index')
+                session_indexes = [session_index] if session_index else None
+            except KeyError:
+                session_indexes = None
 
             sign = sign if sign is not None else self.logout_requests_signed
             sign_post = sign and (


### PR DESCRIPTION
This was broken in commit b69e92585
Fixes https://github.com/IdentityPython/pysaml2/issues/826

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



