### PR TITLE
Fix AttributeError and signature mangling during construction of SOAP request

### DIFF
--- a/src/saml2/client.py
+++ b/src/saml2/client.py
@@ -152,8 +152,8 @@ class Saml2Client(Base):
             # XXX   ^through self.create_authn_request(...)
             # XXX - sign_redirect will add the signature to the query params
             # XXX   ^through self.apply_binding(...)
-            sign_post = False if binding == BINDING_HTTP_REDIRECT else sign
-            sign_redirect = False if binding == BINDING_HTTP_POST and sign else sign
+            sign_redirect = sign and binding == BINDING_HTTP_REDIRECT
+            sign_post = sign and not sign_redirect
 
             reqid, request = self.create_authn_request(
                 destination=destination,
@@ -318,10 +318,8 @@ class Saml2Client(Base):
                 session_indexes = None
 
             sign = sign if sign is not None else self.logout_requests_signed
-            sign_post = sign and (
-                binding == BINDING_HTTP_POST or binding == BINDING_SOAP
-            )
             sign_redirect = sign and binding == BINDING_HTTP_REDIRECT
+            sign_post = sign and not sign_redirect
 
             log_report = {
                 "message": "Invoking SLO on entity",

--- a/src/saml2/httpbase.py
+++ b/src/saml2/httpbase.py
@@ -315,7 +315,7 @@ class HTTPBase(object):
 
         if sign and self.sec:
             _signed = self.sec.sign_statement(soap_message,
-                                              class_name=class_name(request),
+                                              node_name=class_name(request),
                                               node_id=request.id)
             soap_message = _signed
 

--- a/src/saml2/pack.py
+++ b/src/saml2/pack.py
@@ -240,7 +240,7 @@ def make_soap_enveloped_saml_thingy(thingy, header_parts=None):
         if thingy[0:5].lower() == '<?xml':
             logger.debug("thingy0: %s", thingy)
             _part = thingy.split("\n")
-            thingy = "".join(_part[1:])
+            thingy = "\n".join(_part[1:])
         thingy = thingy.replace(PREFIX, "")
         logger.debug("thingy: %s", thingy)
         _child = ElementTree.Element('')

--- a/src/saml2/request.py
+++ b/src/saml2/request.py
@@ -2,7 +2,6 @@ import logging
 
 from saml2 import time_util
 from saml2 import BINDING_HTTP_REDIRECT
-from saml2 import BINDING_HTTP_POST
 from saml2.attribute_converter import to_local
 from saml2.s_utils import OtherError
 
@@ -55,22 +54,22 @@ class Request(object):
         logger.debug("xmlstr: %s, relay_state: %s, sigalg: %s, signature: %s",
                      self.xmlstr, relay_state, sigalg, signature)
 
-        signed_post = must and binding == BINDING_HTTP_POST
-        signed_redirect = must and binding == BINDING_HTTP_REDIRECT
+        sign_redirect = must and binding == BINDING_HTTP_REDIRECT
+        sign_post = must and not sign_redirect
         incorrectly_signed = IncorrectlySigned("Request was not signed correctly")
 
         try:
             self.message = self.signature_check(
                 xmldata,
                 origdoc=origdoc,
-                must=signed_post,
+                must=sign_post,
                 only_valid_cert=only_valid_cert,
             )
         except Exception as e:
             self.message = None
             raise incorrectly_signed from e
 
-        if signed_redirect:
+        if sign_redirect:
             if sigalg is None or signature is None:
                 raise incorrectly_signed
 


### PR DESCRIPTION
Currently, sending SOAP requests using pysaml2 is near-impossible, because two bugs exist:
1. `IDP.apply_binding` for soap without `sign=True` and a pre-signed Message mangles/destroys the signature by removing the line-ends within the signature.
2. `IDP.apply_binding`'s implementation of signing using `use_soap` does not work currently, because instead of `node_name`, `class_name` is passed as a parameter to `securitycontext.sign_statement`, and is raising an `AttributeError`
These two bugs are fixed with this PR

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



