### PR TITLE
Fix logging of attributes with '.' in their name

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -833,7 +833,7 @@ class AuthnResponse(StatusResponse):
 
         # if self.context == "AuthnReq" or self.context == "AttrQuery":
         #    self.ava = self.get_identity()
-        #    logger.debug("--- AVA: %s", self.ava)
+        #    logger.debug("--- AVA: {0}".format(self.ava))
 
         try:
             self.get_subject()
@@ -1036,7 +1036,7 @@ class AuthnResponse(StatusResponse):
 
         if self.context == "AuthnReq" or self.context == "AttrQuery":
             self.ava = self.get_identity()
-            logger.debug("--- AVA: %s", self.ava)
+            logger.debug("--- AVA: {0}".format(self.ava))
 
         return True
 


### PR DESCRIPTION
closes #840 