### PR TITLE
MongoReplicaSetClient removed in pymongo>=4

### DIFF
--- a/src/saml2/mongo_store.py
+++ b/src/saml2/mongo_store.py
@@ -2,8 +2,7 @@ import datetime
 from hashlib import sha1
 import logging
 
-from pymongo import MongoClient
-from pymongo.mongo_replica_set_client import MongoReplicaSetClient
+from pymongo.mongo_client import MongoClient
 import pymongo.uri_parser
 import pymongo.errors
 from saml2.saml import NAMEID_FORMAT_PERSISTENT
@@ -288,8 +287,6 @@ def _mdb_get_database(uri, **kwargs):
         _conn = MongoClient()
         pass
     else:
-        if "replicaset" in _parsed_uri["options"]:
-            connection_factory = MongoReplicaSetClient
         db_name = _parsed_uri.get("database", "pysaml2")
         _conn = connection_factory(uri, **kwargs)
 


### PR DESCRIPTION
As `pymongo` is unpinned in `test-requirements.txt` we now get `pymongo>=4.0.0` when running tests.

from pymongo docs:
> Since PyMongo 3.0, `MongoReplicaSetClient` has been identical to `pymongo.mongo_client.MongoClient`. Applications can simply replace `MongoReplicaSetClient` with `pymongo.mongo_client.MongoClient` and get the same behavior.


### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



