### PR TITLE
Correction: Implement entity category MyAcademicID-ESI for SWAMID

### DIFF
--- a/src/saml2/entity_category/swamid.py
+++ b/src/saml2/entity_category/swamid.py
@@ -84,4 +84,7 @@ RELEASE = {
     (ESI, COCO): MYACADEMICID_ESI + GEANT_COCO,
 }
 
-ONLY_REQUIRED = {COCO: True}
+ONLY_REQUIRED = {
+    COCO: True,
+    (ESI, COCO): True,
+}

--- a/tests/entity_esi_and_coco_sp.xml
+++ b/tests/entity_esi_and_coco_sp.xml
@@ -69,6 +69,7 @@ wHyaxzYldWmVC5omkgZeAdCGpJ316GQF8Zwg/yDOUzm4cvGeIESf1Q6ZxBwI6zGE
     <ns0:AttributeConsumingService index="0">
         <ns0:ServiceName xml:lang="en">esi-coco-SP</ns0:ServiceName>
         <ns0:ServiceDescription xml:lang="en">ESI and COCO SP</ns0:ServiceDescription>
+        <ns0:RequestedAttribute FriendlyName="schacHomeOrganization" Name="urn:oid:1.3.6.1.4.1.25178.1.2.9" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true" />
         <ns0:RequestedAttribute FriendlyName="eduPersonScopedAffiliation" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.9" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true" />
     </ns0:AttributeConsumingService>
   </ns0:SPSSODescriptor>

--- a/tests/test_37_entity_categories.py
+++ b/tests/test_37_entity_categories.py
@@ -298,6 +298,7 @@ def test_filter_ava_esi_coco():
             "entity_categories": ["swamid"]
         }
     }
+
     policy = Policy(policy_conf, mds)
 
     ava = {
@@ -312,17 +313,29 @@ def test_filter_ava_esi_coco():
         ]
     }
 
-    ava = policy.filter(ava, entity_id)
+    requested_attributes = [
+        {
+            'friendly_name': 'eduPersonScopedAffiliation',
+            'name': '1.3.6.1.4.1.5923.1.1.1.9',
+            'name_format': NAME_FORMAT_URI,
+            'is_required': 'true'
+        },
+        {
+            'friendly_name': 'schacHomeOrganization',
+            'name': '1.3.6.1.4.1.25178.1.2.9',
+            'name_format': NAME_FORMAT_URI,
+            'is_required': 'true'
+        }
+    ]
+
+    ava = policy.filter(ava, entity_id, required=requested_attributes)
 
     assert _eq(list(ava.keys()), [
-        'mail',
-        'givenName',
-        'sn',
-        'c',
-        'schacHomeOrganization',
         'eduPersonScopedAffiliation',
+        'schacHomeOrganization',
         'schacPersonalUniqueCode'
     ])
-    assert _eq(ava["mail"], ["test@example.com"])
+    assert _eq(ava["eduPersonScopedAffiliation"], ["student@example.com"])
+    assert _eq(ava["schacHomeOrganization"], ["example.com"])
     assert _eq(ava["schacPersonalUniqueCode"],
                ["urn:schac:personalUniqueCode:int:esi:ladok.se:externtstudentuid-00000000-1111-2222-3333-444444444444"])


### PR DESCRIPTION
correct swamid entity category setup for ESI and COCO
updated test to reflect current usecase

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



