### PR TITLE
Reload metadata in-place

### DIFF
--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -218,19 +218,11 @@ class Entity(HTTPBase):
         """
         logger.debug("Loading new metadata")
         try:
-            new_metadata = self.config.load_metadata(metadata_conf)
+            self.metadata.reload(metadata_conf)
         except Exception as ex:
             logger.error("Loading metadata failed", exc_info=ex)
             return False
 
-        logger.debug("Applying new metadata to main config")
-        ( self.metadata, self.sec.metadata, self.config.metadata ) = [new_metadata]*3
-        policy = getattr(self.config, "_%s_policy" % self.entity_type, None)
-        if policy and policy.metadata_store:
-            logger.debug("Applying new metadata to %s policy", self.entity_type)
-            policy.metadata_store = self.metadata
-
-        logger.debug("Applying new metadata source_id")
         self.sourceid = self.metadata.construct_source_id()
 
         return True

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -1110,6 +1110,15 @@ class MetadataStore(MetaData):
         _md.load()
         self.metadata[key] = _md
 
+    def reload(self, spec):
+        old_metadata = self.metadata
+        self.metadata = {}
+        try:
+            self.imp(spec)
+        except Exception as e:
+            self.metadata = old_metadata
+            raise e
+
     def imp(self, spec):
         # This serves as a backwards compatibility
         if type(spec) is dict:

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -1111,11 +1111,14 @@ class MetadataStore(MetaData):
         self.metadata[key] = _md
 
     def reload(self, spec):
+        # Save the old set of metadata
         old_metadata = self.metadata
         self.metadata = {}
         try:
+            # Reload the metadata based on the spec
             self.imp(spec)
         except Exception as e:
+            # Something went wrong, restore the previous metadata
             self.metadata = old_metadata
             raise e
 


### PR DESCRIPTION
Metadata reloading was previously implemented by loading the metadata,
then replacing references to the old metadata with the new metadata. A
bug in the implementation caused the previous version of the metadata to
be indirectly referenced by the new version of the metadata, resulting
in a steady climb in memory usage.

In fixing the memory leak, I have also changed how metadata is reloaded
to avoid having to replace all existing references, which is prone to
errors and could cause confusing behaviour.