### PR TITLE
Turn warning about no signature verification into an error

### DIFF
--- a/docs/howto/config.rst
+++ b/docs/howto/config.rst
@@ -1174,7 +1174,7 @@ want_assertions_or_response_signed
 Indicates that *either* the Authentication Response *or* the assertions
 contained within the response to this SP must be signed.
 
-Valid values are True or False. Default value is False.
+Valid values are True or False. Default value is True.
 
 This configuration directive **does not** override ``want_response_signed``
 or ``want_assertions_signed``. For example, if ``want_response_signed`` is True

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -10,7 +10,6 @@ import six
 import time
 import logging
 from typing import Mapping
-from warnings import warn as _warn
 
 from saml2.entity import Entity
 
@@ -194,15 +193,14 @@ class Base(Entity):
                 self.want_assertions_or_response_signed,
             ]
         ):
-            warn_msg = (
+            error_msg = (
                 "The SAML service provider accepts "
                 "unsigned SAML Responses and Assertions. "
                 "This configuration is insecure. "
-                "Consider setting want_assertions_signed, want_response_signed "
+                "Set at least one of want_assertions_signed, want_response_signed "
                 "or want_assertions_or_response_signed configuration options."
             )
-            logger.warning(warn_msg)
-            _warn(warn_msg)
+            raise SAMLError(error_msg)
 
         self.artifact2response = {}
 

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -173,7 +173,7 @@ class Base(Entity):
             "authn_requests_signed": False,
             "want_assertions_signed": False,
             "want_response_signed": True,
-            "want_assertions_or_response_signed": False,
+            "want_assertions_or_response_signed": True,
         }
         for attr, val_default in attribute_defaults.items():
             val_config = self.config.getattr(attr, "sp")

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -1860,7 +1860,8 @@ class TestClient:
         parse_authn_response(response)
 
         set_client_want(False, False, False)
-        parse_authn_response(response)
+        with raises(SAMLError):
+            parse_authn_response(response)
 
         # Response is not signed but assertion is signed.
         kwargs["sign_response"] = False
@@ -1893,7 +1894,8 @@ class TestClient:
         parse_authn_response(response)
 
         set_client_want(False, False, False)
-        parse_authn_response(response)
+        with raises(SAMLError):
+            parse_authn_response(response)
 
         # Both response and assertion are signed.
         kwargs["sign_response"] = True
@@ -1922,7 +1924,8 @@ class TestClient:
         parse_authn_response(response)
 
         set_client_want(False, False, False)
-        parse_authn_response(response)
+        with raises(SAMLError):
+            parse_authn_response(response)
 
         # Neither response nor assertion is signed.
         kwargs["sign_response"] = False
@@ -1958,7 +1961,8 @@ class TestClient:
             parse_authn_response(response)
 
         set_client_want(False, False, False)
-        parse_authn_response(response)
+        with raises(SAMLError):
+            parse_authn_response(response)
 
 
 class TestClientNonAsciiAva:


### PR DESCRIPTION
We had a production SP configured with not checking any assertion signature at all. The warning was logged, but not noticed. This is quite undesirable, in other words, highly insecure.

It happened because the SP interfaces with an IdP that does not sign responses, only assertions. So want_response_signed was turned off in config. It was not transparant to the operators that setting just this setting implies that no signatures are checked at all. The warning was logged, but sure, people read logs only when things do not work and the SP worked. The warning was discovered later when researching another problem.

I propose to change the following:

1.  Turn the warning about no signature verification being done into an error. There's really no situation in which an SP should operate without checking any signature on a receveived response or assertion. Making it an error makes this security hole obvious, instead of having to spot the warning somewhere in the logs.
2. Assist users by defaulting the want_assertions_or_response_signed setting to True. This seems a more graceful fallback for a system that has turned off response signing than just not checking any signature at all (or, if 1 is implemented, throwing an error). Because the want_response_signed and want_assertions_signed options override this one if set to True, it should not change behaviour for any non-insecure exising SP config.