### PR TITLE
logging: write less on INFO level

### DIFF
--- a/src/saml2/authn.py
+++ b/src/saml2/authn.py
@@ -146,7 +146,7 @@ class UsernamePasswordMako(UserAuthnMethod):
             "logo_url": logo_url,
             "query": query,
         }
-        logger.info("do_authentication argv: %s" % argv)
+        logger.debug("do_authentication argv: %s" % argv)
         mte = self.template_lookup.get_template(self.mako_template)
         resp.message = mte.render(**argv)
         return resp

--- a/src/saml2/client.py
+++ b/src/saml2/client.py
@@ -142,7 +142,7 @@ class Saml2Client(Base):
                 binding_destinations.append((binding, destination))
 
         for binding, destination in binding_destinations:
-            logger.info("destination to provider: %s", destination)
+            logger.debug("destination to provider: %s", destination)
 
             # XXX - sign_post will embed the signature to the xml doc
             # XXX   ^through self.create_authn_request(...)
@@ -166,7 +166,7 @@ class Saml2Client(Base):
             )
 
             _req_str = str(request)
-            logger.info("AuthNReq: %s", _req_str)
+            logger.debug("AuthNReq: %s", _req_str)
 
             http_info = self.apply_binding(
                 binding,
@@ -215,7 +215,7 @@ class Saml2Client(Base):
         if isinstance(name_id, six.string_types):
             name_id = decode(name_id)
 
-        logger.info("logout request for: %s", name_id)
+        logger.debug("logout request for: %s", name_id)
 
         # find out which IdPs/AAs I should notify
         entity_ids = self.users.issuers_of_info(name_id)
@@ -407,11 +407,11 @@ class Saml2Client(Base):
             response message, response headers and message)
         """
 
-        logger.info("state: %s", self.state)
+        logger.debug("state: %s", self.state)
         status = self.state[response.in_response_to]
-        logger.info("status: %s", status)
+        logger.debug("status: %s", status)
         issuer = response.issuer()
-        logger.info("issuer: %s", issuer)
+        logger.debug("issuer: %s", issuer)
         del self.state[response.in_response_to]
         if status["entity_ids"] == [issuer]:  # done
             self.local_logout(decode(status["name_id"]))
@@ -449,7 +449,7 @@ class Saml2Client(Base):
             else:
                 response_args["binding"] = BINDING_SOAP
 
-            logger.info("Verifying response")
+            logger.debug("Verifying response")
             if response_args:
                 response = _response_func(response.content, **response_args)
             else:
@@ -459,10 +459,10 @@ class Saml2Client(Base):
 
         if response:
             # not_done.remove(entity_id)
-            logger.info("OK response from %s", destination)
+            logger.debug("OK response from %s", destination)
             return response
         else:
-            logger.info("NOT OK response from %s", destination)
+            logger.debug("NOT OK response from %s", destination)
 
         return None
 
@@ -675,7 +675,7 @@ class Saml2Client(Base):
                     'method': "POST
                 }
         """
-        logger.info("logout request: %s", request)
+        logger.debug("logout request: %s", request)
 
         _req = self.parse_logout_request(
             xmlstr=request,

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -277,12 +277,12 @@ class Entity(HTTPBase):
             typ = "SAMLRequest"
 
         if binding == BINDING_HTTP_POST:
-            logger.info("HTTP POST")
+            logger.debug("HTTP POST")
             info = http_form_post_message(msg_str, destination, relay_state, typ)
             info["url"] = destination
             info["method"] = "POST"
         elif binding == BINDING_HTTP_REDIRECT:
-            logger.info("HTTP REDIRECT")
+            logger.debug("HTTP REDIRECT")
             info = http_redirect_message(
                 message=msg_str,
                 location=destination,
@@ -517,7 +517,7 @@ class Entity(HTTPBase):
         except (AttributeError, TypeError):
             to_sign = [(class_name(msg), mid)]
 
-        logger.info("REQUEST: %s", msg)
+        logger.debug("REQUEST: %s", msg)
         return signed_instance_factory(msg, self.sec, to_sign)
 
     # XXX DONE will actually use sign the POST-Binding
@@ -590,7 +590,7 @@ class Entity(HTTPBase):
             )
             req = signed_req
 
-        logger.info("REQUEST: %s", req)
+        logger.debug("REQUEST: %s", req)
         return reqid, req
 
     @staticmethod
@@ -1195,7 +1195,7 @@ class Entity(HTTPBase):
             **rinfo,
         )
 
-        logger.info("Response: %s", response)
+        logger.debug("Response: %s", response)
 
         return response
 
@@ -1268,7 +1268,7 @@ class Entity(HTTPBase):
         msg = element_to_extension_element(self.artifact[artifact])
         response.extension_elements = [msg]
 
-        logger.info("Response: %s", response)
+        logger.debug("Response: %s", response)
 
         return response
 
@@ -1368,7 +1368,7 @@ class Entity(HTTPBase):
             **rinfo,
         )
 
-        logger.info("Response: %s", response)
+        logger.debug("Response: %s", response)
 
         return response
 
@@ -1430,7 +1430,7 @@ class Entity(HTTPBase):
         try:
             response = response_cls(self.sec, **kwargs)
         except Exception as exc:
-            logger.info(str(exc))
+            logger.error(str(exc))
             raise
 
         xmlstr = self.unravel(xmlstr, binding, response_cls.msgtype)

--- a/src/saml2/httpbase.py
+++ b/src/saml2/httpbase.py
@@ -319,11 +319,11 @@ class HTTPBase(object):
             args["headers"] = dict(args["headers"])
             response = self.send(**args)
         except Exception as exc:
-            logger.info("HTTPClient exception: %s", str(exc))
+            logger.error("HTTPClient exception: %s", str(exc))
             raise
 
         if response.status_code == 200:
-            logger.info("SOAP response: %s", response.text)
+            logger.debug("SOAP response: %s", response.text)
             return response
         else:
             raise HTTPError("%d:%s" % (response.status_code, response.content))

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -858,7 +858,7 @@ class MetaDataExtern(InMemoryMetaData):
             _txt = response.content
             return self.parse_and_check_signature(_txt)
         else:
-            logger.info("Response status: %s", response.status_code)
+            logger.error("Response status: %s", response.status_code)
             raise SourceNotFound(self.url)
 
 
@@ -952,13 +952,13 @@ class MetaDataMDX(InMemoryMetaData):
         )
         if response.status_code != 200:
             error_msg = "Fething {item}: Got response status {status}".format(item=item, status=response.status_code)
-            logger.info(error_msg)
+            logger.warning(error_msg)
             raise KeyError(error_msg)
 
         _txt = response.content
         if not self.parse_and_check_signature(_txt):
             error_msg = "Fething {item}: invalid signature".format(item=item)
-            logger.info(error_msg)
+            logger.error(error_msg)
             raise KeyError(error_msg)
 
         curr_time = str_to_time(instant())

--- a/src/saml2/request.py
+++ b/src/saml2/request.py
@@ -96,7 +96,7 @@ class Request(object):
             logger.info("Request data: %s", xmldata)
             raise incorrectly_signed
 
-        logger.info("Request message: %s", self.message)
+        logger.debug("Request message: %s", self.message)
 
         try:
             valid_instance(self.message)
@@ -111,7 +111,7 @@ class Request(object):
         certs = self.sec.metadata.certs(issuer, "any", "signing")
         logger.debug("Certs to verify request sig: %s, _saml_msg: %s", certs, _saml_msg)
         verified = any(verify_redirect_signature(_saml_msg, self.sec.sec_backend, cert) for cert_name, cert in certs)
-        logger.info("Redirect request signature check: %s", verified)
+        logger.debug("Redirect request signature check: %s", verified)
         return verified
 
     def issue_instant_ok(self):

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -310,9 +310,9 @@ class StatusResponse(object):
 
     def _postamble(self):
         if not self.response:
-            logger.error("Response was not correctly signed")
+            logger.warning("Response was not correctly signed")
             if self.xmlstr:
-                logger.info("Response: %s", self.xmlstr)
+                logger.debug("Response: %s", self.xmlstr)
             raise IncorrectlySigned()
 
         logger.debug("response: %s", self.response)
@@ -320,7 +320,7 @@ class StatusResponse(object):
         try:
             valid_instance(self.response)
         except NotValid as exc:
-            logger.error("Not valid response: %s", exc.args[0])
+            logger.warning("Not valid response: %s", exc.args[0])
             self._clear()
             return self
 
@@ -380,7 +380,7 @@ class StatusResponse(object):
 
     def status_ok(self):
         status = self.response.status
-        logger.info("status: %s", status)
+        logger.debug("status: %s", status)
 
         if not status or status.status_code.value == samlp.STATUS_SUCCESS:
             return True
@@ -390,7 +390,7 @@ class StatusResponse(object):
         err_cls = STATUSCODE2EXCEPTION.get(err_code, StatusError)
 
         msg = "Unsuccessful operation: {status}\n{msg} from {code}".format(status=status, msg=err_msg, code=err_code)
-        logger.info(msg)
+        logger.debug(msg)
         raise err_cls(msg)
 
     def issue_instant_ok(self):
@@ -1406,9 +1406,9 @@ class AssertionIDResponse(object):
 
     def _postamble(self):
         if not self.response:
-            logger.error("Response was not correctly signed")
+            logger.warning("Response was not correctly signed")
             if self.xmlstr:
-                logger.info("Response: %s", self.xmlstr)
+                logger.debug("Response: %s", self.xmlstr)
             raise IncorrectlySigned()
 
         logger.debug("response: %s", self.response)

--- a/src/saml2/server.py
+++ b/src/saml2/server.py
@@ -986,7 +986,7 @@ class Server(Entity):
         if sign_response:
             return self.sign(_resp, sign_alg=sign_alg, digest_alg=digest_alg)
         else:
-            logger.info("Message: %s", _resp)
+            logger.debug("Message: %s", _resp)
             return _resp
 
     # XXX DONE idp create > _response


### PR DESCRIPTION
pysaml2 log messages were too verbose on INFO level to handle them in a production instance, therefore many messages have been redirected to DEBUG level. On the other hand, some error cases also were sending its log on INFO, these have been redirected to WARNING or ERROR level.
### Checklist

* [x] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [ ] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant