### PR TITLE
Use resp.name_id instead of resp.assertion.subject.name_id for cases that using encrypted-id

### DIFF
--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -807,7 +807,7 @@ class Base(Entity):
             logger.error("Response type not supported: %s", saml2.class_name(resp))
             return None
 
-        if resp.assertion and len(resp.response.encrypted_assertion) == 0 and resp.assertion.subject.name_id:
+        if resp.assertion and len(resp.response.encrypted_assertion) == 0 and resp.name_id:
             self.users.add_information_about_person(resp.session_info())
             logger.info("--- ADDED person info ----")
 


### PR DESCRIPTION
### Description

##### The feature or problem addressed by this PR

I faced the same problem as https://github.com/IdentityPython/pysaml2/issues/281 when trying to log out from an IdP. 
And after some debugging, I found out the cause. During log-in process, the value of `resp.assertion.subject.name_id` at the changed line is `None` so that user's information cannot be saved into the identity cache. I guess the reason is that the decrypted name_id here ( https://github.com/IdentityPython/pysaml2/blob/master/src/saml2/response.py#L771-L775 ) isn't stored to `subject.name_id` but to `self.name_id` (`self` is AuthnResponse object instance).

(The response of our target IdP has `<saml:EncryptedID>` under `<saml:Subject>`.)


##### What your changes do and why you chose this solution

I think that using `resp.name_id` here is more reasonable since it will have correct value for both unencrypted and encrypted name ID cases. And this change really solved my problem.

### Checklist

* [x] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [ ] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant

Sorry that I'm not really familiar with SAML and this repo. Not sure about how to write the tests or document for this case. Anyone can give help for this?