### PR TITLE
Treat requested subject id as requested attribute

### DIFF
--- a/src/saml2/assertion.py
+++ b/src/saml2/assertion.py
@@ -559,7 +559,7 @@ class Policy:
         required_attributes = spec.get("required", [])
         optional_attributes = spec.get("optional", [])
         required_subject_id = metadata_store.subject_id_requirement(sp_entity_id) if metadata_store else None
-        if required_subject_id:
+        if required_subject_id and required_subject_id not in required_attributes:
             required_attributes.append(required_subject_id)
         return self.filter(
             ava,

--- a/src/saml2/assertion.py
+++ b/src/saml2/assertion.py
@@ -556,11 +556,16 @@ class Policy:
 
         metadata_store = metadata or self.metadata_store
         spec = metadata_store.attribute_requirement(sp_entity_id) or {} if metadata_store else {}
+        required_attributes = spec.get("required", [])
+        optional_attributes = spec.get("optional", [])
+        required_subject_id = metadata_store.subject_id_requirement(sp_entity_id) if metadata_store else None
+        if required_subject_id:
+            required_attributes.append(required_subject_id)
         return self.filter(
             ava,
             sp_entity_id,
-            required=spec.get("required"),
-            optional=spec.get("optional"),
+            required=required_attributes or None,
+            optional=optional_attributes or None,
         )
 
     def conditions(self, sp_entity_id):

--- a/tests/entity_esi_and_coco_sp.xml
+++ b/tests/entity_esi_and_coco_sp.xml
@@ -7,6 +7,9 @@
               <saml:AttributeValue>https://myacademicid.org/entity-categories/esi</saml:AttributeValue>
               <saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
           </saml:Attribute>
+          <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:profiles:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+              <saml:AttributeValue>any</saml:AttributeValue>
+          </saml:Attribute>
       </mdattr:EntityAttributes></ns0:Extensions>
   <ns0:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <ns0:KeyDescriptor use="encryption">
@@ -65,7 +68,7 @@ wHyaxzYldWmVC5omkgZeAdCGpJ316GQF8Zwg/yDOUzm4cvGeIESf1Q6ZxBwI6zGE
     </ns0:KeyDescriptor>
     <ns0:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://esi-coco.example.edu/saml2/ls/"/>
     <ns0:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://esi-coco.example.edu/saml2/acs/" index="1"/>
-    <!-- Require eduPersonTargetedID -->
+    <!-- Require schacHomeOrganization and eduPersonScopedAffiliation -->
     <ns0:AttributeConsumingService index="0">
         <ns0:ServiceName xml:lang="en">esi-coco-SP</ns0:ServiceName>
         <ns0:ServiceDescription xml:lang="en">ESI and COCO SP</ns0:ServiceDescription>

--- a/tests/entity_personalized_sp.xml
+++ b/tests/entity_personalized_sp.xml
@@ -64,7 +64,6 @@ wHyaxzYldWmVC5omkgZeAdCGpJ316GQF8Zwg/yDOUzm4cvGeIESf1Q6ZxBwI6zGE
     </ns0:KeyDescriptor>
     <ns0:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://personalized.example.edu/saml2/ls/"/>
     <ns0:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://personalized.example.edu/saml2/acs/" index="1"/>
-    <!-- Require eduPersonTargetedID -->
     <ns0:AttributeConsumingService index="0">
        <ns0:ServiceName xml:lang="en">personalized-SP</ns0:ServiceName>
         <ns0:ServiceDescription xml:lang="en">refeds personalized access SP</ns0:ServiceDescription>

--- a/tests/test_30_mdstore.py
+++ b/tests/test_30_mdstore.py
@@ -189,6 +189,12 @@ METADATACONF = {
             "metadata": [(full_path("empty_metadata_file.xml"),)],
         }
     ],
+    "17": [
+        {
+            "class": "saml2.mdstore.MetaDataFile",
+            "metadata": [(full_path("entity_esi_and_coco_sp.xml"),)],
+        }
+    ],
 }
 
 
@@ -652,6 +658,17 @@ def test_registration_info_no_policy():
     assert "http://eduid.hu" == registration_info["registration_authority"]
     assert registration_info["registration_instant"] is None
     assert registration_info["registration_policy"] == {}
+
+
+def test_subject_id_requirement():
+    mds = MetadataStore(ATTRCONV, sec_config, disable_ssl_certificate_validation=True)
+    mds.imp(METADATACONF["17"])
+    required_subject_id = mds.subject_id_requirement(entity_id="https://esi-coco.example.edu/saml2/metadata/")
+    assert required_subject_id["__class__"] == "urn:oasis:names:tc:SAML:2.0:metadata&RequestedAttribute"
+    assert required_subject_id["name"] == "urn:oasis:names:tc:SAML:attribute:pairwise-id"
+    assert required_subject_id["name_format"] == "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+    assert required_subject_id["friendly_name"] == "pairwise-id"
+    assert required_subject_id["is_required"] == "true"
 
 
 def test_extension():


### PR DESCRIPTION
### Description
If an SP requests a subject id using SAML V2.0 Subject Identifier Attributes Profile Version we should not require the SP to also add the request to requested attributes.

##### The feature or problem addressed by this PR
When using entity categories that specifies attributes that should only be released when required an SP needs to request subject id in both entity attributes and in requested attributes. With this PR the SP only needs to request the subject id in entity attributes as defined by the committee specification.

##### What your changes do and why you chose this solution
I found that this way play nice with entity category filtering.


### Checklist

* [X] Checked that no other issues or pull requests exist for the same issue/change
* [X] Added tests covering the new functionality
* [ ] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
