### PR TITLE
Ensure the ID of each Signature element is unique when signing an encrypted assertion

### DIFF
--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -870,7 +870,7 @@ class Entity(HTTPBase):
                         _assertion.signature = pre_signature_part(
                             _assertion.id,
                             self.sec.my_cert,
-                            1,
+                            2,
                             sign_alg=sign_alg,
                             digest_alg=digest_alg,
                         )


### PR DESCRIPTION
If assertion is gonna be encrypted and the response and the assertion are signed, both signatures will have an ID of `signature1` which leads to an invalid xml because the ids have to be unique. A similar issue has been reported and fixed the same way in server.py
with this commit: 4375361939e942c4dd666d3ca4e1159858404bc4
from this pull request: https://github.com/IdentityPython/pysaml2/pull/364
### Description

##### The feature or problem addressed by this PR

<!-- an explaination of the issue that is being resolved with this PR -->
<!-- or, an explaination of the feature that is being added with this PR -->
<!-- or, link to an issue describing the problem -->


##### What your changes do and why you chose this solution

<!-- description of the technical changes that help resolve the issue -->


### Checklist

* [ ] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [x] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
