### PR TITLE
Disable REFEDS Access entity categories for Swamid

### DIFF
--- a/src/saml2/entity_category/swamid.py
+++ b/src/saml2/entity_category/swamid.py
@@ -113,10 +113,12 @@ RELEASE = {
     ESI: MYACADEMICID_ESI,
     (ESI, COCOv1): MYACADEMICID_ESI + GEANT_COCO,
     (ESI, COCOv2): MYACADEMICID_ESI + REFEDS_COCO,
+    # XXX: disabled temporarily until we can figure out how to handle them
+    #      these need to be able to be combined with other categories just not with each other
     # no aggregation categories
-    PERSONALIZED: REFEDS_PERSONALIZED_ACCESS,
-    PSEUDONYMOUS: REFEDS_PSEUDONYMOUS_ACCESS,
-    ANONYMOUS: REFEDS_ANONYMOUS_ACCESS,
+    # PERSONALIZED: REFEDS_PERSONALIZED_ACCESS,
+    # PSEUDONYMOUS: REFEDS_PSEUDONYMOUS_ACCESS,
+    # ANONYMOUS: REFEDS_ANONYMOUS_ACCESS,
 }
 
 ONLY_REQUIRED = {

--- a/tests/test_37_entity_categories.py
+++ b/tests/test_37_entity_categories.py
@@ -1,5 +1,7 @@
 from contextlib import closing
 
+import pytest
+
 from pathutils import full_path
 
 from saml2 import config
@@ -291,6 +293,7 @@ def test_filter_ava_esi_coco():
     )
 
 
+@pytest.mark.skip("Temporarily disabled")
 def test_filter_ava_refeds_anonymous_access():
     entity_id = "https://anonymous.example.edu/saml2/metadata/"
     mds = MetadataStore(ATTRCONV, sec_config, disable_ssl_certificate_validation=True)
@@ -319,6 +322,7 @@ def test_filter_ava_refeds_anonymous_access():
     assert _eq(ava["schacHomeOrganization"], ["example.com"])
 
 
+@pytest.mark.skip("Temporarily disabled")
 def test_filter_ava_refeds_pseudonymous_access():
     entity_id = "https://pseudonymous.example.edu/saml2/metadata/"
     mds = MetadataStore(ATTRCONV, sec_config, disable_ssl_certificate_validation=True)
@@ -351,6 +355,7 @@ def test_filter_ava_refeds_pseudonymous_access():
     assert _eq(ava["schacHomeOrganization"], ["example.com"])
 
 
+@pytest.mark.skip("Temporarily disabled")
 def test_filter_ava_refeds_personalized_access():
     entity_id = "https://personalized.example.edu/saml2/metadata/"
     mds = MetadataStore(ATTRCONV, sec_config, disable_ssl_certificate_validation=True)


### PR DESCRIPTION
### Description

Turns out the implementation of no aggregation ECs was not quite what was needed to comply with the policy for these. Apparently they should only be no aggregation between personalized, pseudonymous and anonymous but allow aggregation of other ECs.

##### What your changes do and why you chose this solution

We should have a discussion of how this kind of entity category support can be implemented in pysaml.

### Checklist

* [X] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [ ] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
