### PR TITLE
delete_one does not accept just a key

### DIFF
--- a/src/saml2/mongo_store.py
+++ b/src/saml2/mongo_store.py
@@ -98,8 +98,7 @@ class SessionStorageMDB:
     def remove_authn_statements(self, name_id):
         logger.debug("remove authn about: %s", name_id)
         key = sha1(code_binary(name_id)).hexdigest()
-        for item in self.assertion.find({"name_id_key": key}):
-            self.assertion.delete_one(item["_id"])
+        self.assertion.delete_many(filter={"name_id_key": key})
 
     def get_authn_statements(self, name_id, session_index=None, requested_context=None):
         """
@@ -220,13 +219,11 @@ class MDB:
     def remove(self, key=None, **kwargs):
         if key is None:
             if kwargs:
-                for item in self.db.find(kwargs):
-                    self.db.delete_one(item["_id"])
+                self.db.delete_many(filter=kwargs)
         else:
             doc = {self.primary_key: key}
             doc.update(kwargs)
-            for item in self.db.find(doc):
-                self.db.delete_one(item["_id"])
+            self.db.delete_many(filter=doc)
 
     def keys(self):
         for item in self.db.find():


### PR DESCRIPTION

### Description

##### The feature or problem addressed by this PR
delete_one do not accept just a key as remove previously did
change delete_one to delete_many instead of iterating through results deleting all found documents


### Checklist

* [X] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [X] Updated documentation OR the change is too minor to be documented
* [X] Updated CHANGELOG.md OR changes are insignificant
