### PR TITLE
Fix: render extensions also for EntityDescriptor and IdPSSODescriptor

### DIFF
--- a/src/saml2/metadata.py
+++ b/src/saml2/metadata.py
@@ -675,6 +675,17 @@ def entity_descriptor(confd):
     if confd.contact_person is not None:
         entd.contact_person = do_contact_persons_info(confd.contact_person)
 
+    exts = confd.extensions
+    if exts:
+        if not entd.extensions:
+            entd.extensions = md.Extensions()
+
+        for key, val in exts.items():
+            _ext = do_extensions(key, val)
+            if _ext:
+                for _e in _ext:
+                    entd.extensions.add_extension_element(_e)
+
     if confd.entity_attributes:
         if not entd.extensions:
             entd.extensions = md.Extensions()

--- a/src/saml2/metadata.py
+++ b/src/saml2/metadata.py
@@ -589,6 +589,17 @@ def do_aa_descriptor(conf, cert=None, enc_cert=None):
     aad = md.AttributeAuthorityDescriptor()
     aad.protocol_support_enumeration = samlp.NAMESPACE
 
+    exts = conf.getattr("extensions", "aa")
+    if exts:
+        if aad.extensions is None:
+            aad.extensions = md.Extensions()
+
+        for key, val in exts.items():
+            _ext = do_extensions(key, val)
+            if _ext:
+                for _e in _ext:
+                    aad.extensions.add_extension_element(_e)
+
     endps = conf.getattr("endpoints", "aa")
 
     if endps:
@@ -617,6 +628,17 @@ def do_aq_descriptor(conf, cert=None, enc_cert=None):
     aqs = md.AuthnAuthorityDescriptor()
     aqs.protocol_support_enumeration = samlp.NAMESPACE
 
+    exts = conf.getattr("extensions", "aa")
+    if exts:
+        if aqs.extensions is None:
+            aqs.extensions = md.Extensions()
+
+        for key, val in exts.items():
+            _ext = do_extensions(key, val)
+            if _ext:
+                for _e in _ext:
+                    aqs.extensions.add_extension_element(_e)
+
     endps = conf.getattr("endpoints", "aq")
 
     if endps:
@@ -636,6 +658,17 @@ def do_pdp_descriptor(conf, cert=None, enc_cert=None):
     pdp = md.PDPDescriptor()
 
     pdp.protocol_support_enumeration = samlp.NAMESPACE
+
+    exts = conf.getattr("extensions", "pdp")
+    if exts:
+        if pdp.extensions is None:
+            pdp.extensions = md.Extensions()
+
+        for key, val in exts.items():
+            _ext = do_extensions(key, val)
+            if _ext:
+                for _e in _ext:
+                    pdp.extensions.add_extension_element(_e)
 
     endps = conf.getattr("endpoints", "pdp")
 

--- a/src/saml2/metadata.py
+++ b/src/saml2/metadata.py
@@ -533,6 +533,17 @@ def do_idpsso_descriptor(conf, cert=None, enc_cert=None):
     idpsso = md.IDPSSODescriptor()
     idpsso.protocol_support_enumeration = samlp.NAMESPACE
 
+    exts = conf.getattr("extensions", "idp")
+    if exts:
+        if idpsso.extensions is None:
+            idpsso.extensions = md.Extensions()
+
+        for key, val in exts.items():
+            _ext = do_extensions(key, val)
+            if _ext:
+                for _e in _ext:
+                    idpsso.extensions.add_extension_element(_e)
+
     endps = conf.getattr("endpoints", "idp")
     if endps:
         for (endpoint, instlist) in do_endpoints(endps, ENDPOINTS["idp"]).items():


### PR DESCRIPTION

Hi @c00kiemon5ter ,

I have noticed that while extra (metadata) extensions given as part of SP config are rendered in the metadata, they're ignored when given at the EntityDescriptor level (where e.g. RegistrationInfo should be rendered).

I have followed the style of how an SPSSODescriptor renderes the extensions and added it for EntityDescriptor - works as expected.

For completeness, I've also checked what other code paths might suffer from the same issue and added the rendering of extensions also for IdPSSODescriptor.

I see there are also similar functions for AA, AQ and PDP descriptors - I could add the same schematic code for completeness, but wanted to check with you first.

Your thoughts on this?

Should I cover the remaining descriptor types and would you then be happy to merge this PR?

Thanks a lot in advance for getting back to me.

Cheers,
Vlad


### Checklist

* [X] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [ ] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
