### PR TITLE
Refeds entity category handling improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ paste = {optional = true, version = "*"}
 pyopenssl = "*"
 python-dateutil = "*"
 pytz = "*"
+pydantic = {version = ">=1.7.4"}
 "repoze.who" = {optional = true, version = "*"}
 requests = "^2"
 xmlschema = ">=1.2.1"

--- a/src/saml2/assertion.py
+++ b/src/saml2/assertion.py
@@ -606,22 +606,22 @@ class Policy:
             return default
         return attribute_restriction
 
-    def get_nameid_format(self, sp_entity_id):
+    def get_nameid_format(self, sp_entity_id: str):
         """Get the NameIDFormat to used for the entity id
         :param: The SP entity ID
-        :retur: The format
+        :return: The format
         """
         return self.get("nameid_format", sp_entity_id, saml.NAMEID_FORMAT_TRANSIENT)
 
-    def get_name_form(self, sp_entity_id):
+    def get_name_form(self, sp_entity_id: str):
         """Get the NameFormat to used for the entity id
         :param: The SP entity ID
-        :retur: The format
+        :return: The format
         """
 
         return self.get("name_form", sp_entity_id, default=NAME_FORMAT_URI)
 
-    def get_lifetime(self, sp_entity_id):
+    def get_lifetime(self, sp_entity_id: str):
         """The lifetime of the assertion
         :param sp_entity_id: The SP entity ID
         :param: lifetime as a dictionary
@@ -629,7 +629,7 @@ class Policy:
         # default is a hour
         return self.get("lifetime", sp_entity_id, {"hours": 1})
 
-    def get_attribute_restrictions(self, sp_entity_id):
+    def get_attribute_restrictions(self, sp_entity_id: str) -> Optional[AttributeRestrictions]:
         """Return the attribute restriction for SP that want the information
 
         :param sp_entity_id: The SP entity ID
@@ -638,7 +638,7 @@ class Policy:
 
         return self.get("attribute_restrictions", sp_entity_id)
 
-    def get_fail_on_missing_requested(self, sp_entity_id):
+    def get_fail_on_missing_requested(self, sp_entity_id: str):
         """Return the whether the IdP should should fail if the SPs
         requested attributes could not be found.
 
@@ -648,7 +648,7 @@ class Policy:
 
         return self.get("fail_on_missing_requested", sp_entity_id, default=True)
 
-    def get_sign(self, sp_entity_id):
+    def get_sign(self, sp_entity_id: str):
         """
         Possible choices
         "sign": ["response", "assertion", "on_demand"]
@@ -691,7 +691,7 @@ class Policy:
             required=required,
         )
 
-    def not_on_or_after(self, sp_entity_id):
+    def not_on_or_after(self, sp_entity_id: str):
         """When the assertion stops being valid, should not be
         used after this time.
 
@@ -758,7 +758,7 @@ class Policy:
 
         return subject_ava or {}
 
-    def restrict(self, ava, sp_entity_id, metadata=None):
+    def restrict(self, ava: AttributeValues, sp_entity_id: str, metadata: Optional[MetadataStore] = None):
         """Identity attribute names are expected to be expressed as FriendlyNames
 
         :return: A filtered ava according to the IdPs/AAs rules and

--- a/src/saml2/entity_category/swamid.py
+++ b/src/saml2/entity_category/swamid.py
@@ -100,8 +100,6 @@ NREN = "http://www.swamid.se/category/nren-service"  # Deprecated from 2021-03-3
 HEI = "http://www.swamid.se/category/hei-service"  # Deprecated from 2021-03-31
 
 RELEASE = {
-    # NOTICE: order is important
-    # no-aggregation categories need to come last and in order of least to most restrictive
     "": [],
     SFS_1993_1153: ["norEduPersonNIN", "eduPersonAssurance"],
     (RESEARCH_AND_EDUCATION, EU): NAME + STATIC_ORG_INFO + OTHER,
@@ -113,12 +111,6 @@ RELEASE = {
     ESI: MYACADEMICID_ESI,
     (ESI, COCOv1): MYACADEMICID_ESI + GEANT_COCO,
     (ESI, COCOv2): MYACADEMICID_ESI + REFEDS_COCO,
-    # XXX: disabled temporarily until we can figure out how to handle them
-    #      these need to be able to be combined with other categories just not with each other
-    # no aggregation categories
-    # PERSONALIZED: REFEDS_PERSONALIZED_ACCESS,
-    # PSEUDONYMOUS: REFEDS_PSEUDONYMOUS_ACCESS,
-    # ANONYMOUS: REFEDS_ANONYMOUS_ACCESS,
 }
 
 ONLY_REQUIRED = {
@@ -128,8 +120,42 @@ ONLY_REQUIRED = {
     (ESI, COCOv2): True,
 }
 
-NO_AGGREGATION = {
-    PERSONALIZED: True,
-    PSEUDONYMOUS: True,
-    ANONYMOUS: True,
-}
+# These restrictions are parsed (and validated) into a list of saml2.assertion.EntityCategoryRule instances.
+RESTRICTIONS = [
+    {
+        "match": {
+            "required": [PERSONALIZED],
+            "conflicts": [PSEUDONYMOUS, ANONYMOUS],
+        },
+        "attributes": REFEDS_PERSONALIZED_ACCESS,
+    },
+    {
+        "match": {
+            "required": [PSEUDONYMOUS],
+            "conflicts": [ANONYMOUS],
+        },
+        "attributes": REFEDS_PSEUDONYMOUS_ACCESS,
+    },
+    {
+        "match": {
+            "required": [ANONYMOUS],
+        },
+        "attributes": REFEDS_ANONYMOUS_ACCESS,
+    },
+    # Example of conversion of some of the rules in RELEASE to this new format:
+    #
+    # {
+    #     "match": {
+    #         "required": [COCOv1],
+    #     },
+    #     "attributes": GEANT_COCO,
+    #     "only_required": True,
+    # },
+    # {
+    #     "match": {
+    #         "required": [ESI, COCOv1],
+    #     },
+    #     "attributes": MYACADEMICID_ESI + GEANT_COCO,
+    #     "only_required": True,
+    # },
+]

--- a/src/saml2/s_utils.py
+++ b/src/saml2/s_utils.py
@@ -8,6 +8,7 @@ import random
 import string
 import sys
 import traceback
+from typing import Union
 import zlib
 
 from saml2 import VERSION
@@ -327,7 +328,7 @@ def do_ava(val, typ=""):
     return attrval
 
 
-def do_attribute(val, typ, key):
+def do_attribute(val, typ, key: Union[str, tuple]) -> saml.Attribute:
     attr = saml.Attribute()
     attrval = do_ava(val, typ)
     if attrval:

--- a/src/saml2/typing.py
+++ b/src/saml2/typing.py
@@ -1,0 +1,30 @@
+# Type information for common pysaml2 data types, often found in configuration etc.
+#
+
+from typing import Literal
+from typing import Mapping
+from typing import Optional
+from typing import TypedDict
+from typing import Union
+
+
+# Required attributes are specified as dicts, e.g.:
+#
+#   {
+#       "friendly_name": "eduPersonScopedAffiliation",
+#       "name": "1.3.6.1.4.1.5923.1.1.1.9",
+#       "name_format": NAME_FORMAT_URI,
+#       "is_required": "true",
+#       "attribute_value": [{"text": Any, ...}]
+#   }
+class AttributeAsDict(TypedDict):
+    friendly_name: Optional[str]
+    name: str
+    name_format: str
+    is_required: Union[Literal["true"], Literal["false"]]
+    attribute_value: Optional[list[Mapping[str, str]]]
+
+
+# Type for the common 'ava' parameter.
+AttributeValues = dict[str, Union[list[str], str]]
+AttributeValuesStrict = dict[str, list[str]]

--- a/tests/entity_personalized_sp.xml
+++ b/tests/entity_personalized_sp.xml
@@ -5,6 +5,7 @@
       <mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
           <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
               <saml:AttributeValue>https://refeds.org/category/personalized</saml:AttributeValue>
+              <saml:AttributeValue>https://refeds.org/category/code-of-conduct/v2</saml:AttributeValue>
           </saml:Attribute>
       </mdattr:EntityAttributes></ns0:Extensions>
   <ns0:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
@@ -67,6 +68,7 @@ wHyaxzYldWmVC5omkgZeAdCGpJ316GQF8Zwg/yDOUzm4cvGeIESf1Q6ZxBwI6zGE
     <ns0:AttributeConsumingService index="0">
        <ns0:ServiceName xml:lang="en">personalized-SP</ns0:ServiceName>
         <ns0:ServiceDescription xml:lang="en">refeds personalized access SP</ns0:ServiceDescription>
+        <ns0:RequestedAttribute FriendlyName="eduPersonTargetedId" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true" />
     </ns0:AttributeConsumingService>
   </ns0:SPSSODescriptor>
   <ns0:Organization>

--- a/tests/test_37_entity_categories.py
+++ b/tests/test_37_entity_categories.py
@@ -14,6 +14,7 @@ from saml2.mdie import to_dict
 from saml2.mdstore import MetadataStore
 from saml2.saml import NAME_FORMAT_URI
 from saml2.server import Server
+from saml2.typing import AttributeAsDict
 
 
 ATTRCONV = ac_factory(full_path("attributemaps"))
@@ -374,7 +375,11 @@ def test_filter_ava_refeds_personalized_access():
         "subject-id": ["subject-id@example.com"],
     }
 
-    ava = policy.filter(ava, entity_id)
+    attribute_requirements = mds.attribute_requirement(entity_id)
+    required = attribute_requirements.get("required", [])
+    optional = attribute_requirements.get("optional", [])
+
+    ava = policy.filter(ava, entity_id, required=required, optional=optional)
 
     assert _eq(
         list(ava.keys()),
@@ -387,6 +392,7 @@ def test_filter_ava_refeds_personalized_access():
             "eduPersonScopedAffiliation",
             "eduPersonAssurance",
             "schacHomeOrganization",
+            "eduPersonTargetedID",
         ],
     )
     assert _eq(ava["subject-id"], ["subject-id@example.com"])

--- a/tests/test_37_entity_categories.py
+++ b/tests/test_37_entity_categories.py
@@ -293,7 +293,6 @@ def test_filter_ava_esi_coco():
     )
 
 
-@pytest.mark.skip("Temporarily disabled")
 def test_filter_ava_refeds_anonymous_access():
     entity_id = "https://anonymous.example.edu/saml2/metadata/"
     mds = MetadataStore(ATTRCONV, sec_config, disable_ssl_certificate_validation=True)
@@ -322,7 +321,6 @@ def test_filter_ava_refeds_anonymous_access():
     assert _eq(ava["schacHomeOrganization"], ["example.com"])
 
 
-@pytest.mark.skip("Temporarily disabled")
 def test_filter_ava_refeds_pseudonymous_access():
     entity_id = "https://pseudonymous.example.edu/saml2/metadata/"
     mds = MetadataStore(ATTRCONV, sec_config, disable_ssl_certificate_validation=True)
@@ -355,7 +353,6 @@ def test_filter_ava_refeds_pseudonymous_access():
     assert _eq(ava["schacHomeOrganization"], ["example.com"])
 
 
-@pytest.mark.skip("Temporarily disabled")
 def test_filter_ava_refeds_personalized_access():
     entity_id = "https://personalized.example.edu/saml2/metadata/"
     mds = MetadataStore(ATTRCONV, sec_config, disable_ssl_certificate_validation=True)


### PR DESCRIPTION
### Description

##### The feature or problem addressed by this PR

Complete the changes needed to entity category handling in order to support refeds personalized, pseudononymous and anonymous.


##### What your changes do and why you chose this solution

A new format for entity category restrictions was needed to support
being able to express that certain categories should not be "mixed"
(refeds personalized, pseudonymous, anonymous).
    
In discussions, it was determined that Pydantic was a suitable tool to
load such configuration in a way that made it convenient, and safe, to
work with.
    
This code is backwards compatible with the old entity categories module
data format (RELEASE and ONLY_REQUIRED, two dictionaries) but also adds
support for a new format, RESTRICTIONS which is a list of dicts that
Pydantic will marshal into EntityCategoryRule objects when loaded.
    
As often is the case when typing, the scope of the change spread a
little to related functions and classes.

### Checklist

* [ ] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [ ] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
