### PR TITLE
Add support for xmlsec1 1.3

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -471,14 +471,14 @@ def import_rsa_key_from_file(filename):
     return key
 
 
-def parse_xmlsec_verify_output(xmlsec_vsn, output):
+def parse_xmlsec_verify_output(output, version=None):
     """Parse the output from xmlsec to try to find out if the
     command was successfull or not.
 
     :param output: The output from Popen
     :return: A boolean; True if the command was a success otherwise False
     """
-    if xmlsec_vsn < (1, 3):
+    if version is None or version < (1, 3):
         for line in output.splitlines():
             if line == "OK":
                 return True
@@ -600,8 +600,17 @@ def verify_redirect_signature(saml_msg, crypto, cert=None, sigkey=None):
 
 
 class CryptoBackend:
+    @property
     def version(self):
         raise NotImplementedError()
+
+    @property
+    def version_nums(self):
+        try:
+            vns = tuple(int(t) for t in self.version)
+        except ValueError:
+            vns = (0, 0, 0)
+        return vns
 
     def encrypt(self, text, recv_key, template, key_type):
         raise NotImplementedError()
@@ -636,14 +645,12 @@ class CryptoBackendXmlSec1(CryptoBackend):
             raise ValueError("xmlsec_binary should be of type string")
         self.xmlsec = xmlsec_binary
         self.delete_tmpfiles = delete_tmpfiles
-        vsn = self.version()
-        [maj_num_str, min_num_str] = vsn.split('.')[0:2]
-        self.vsn = (int(maj_num_str), int(min_num_str))
         try:
             self.non_xml_crypto = RSACrypto(kwargs["rsa_key"])
         except KeyError:
             pass
 
+    @property
     def version(self):
         com_list = [self.xmlsec, "--version"]
         pof = Popen(com_list, stderr=PIPE, stdout=PIPE)
@@ -652,7 +659,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
         try:
             return content.split(" ")[1]
         except IndexError:
-            return ""
+            return "0.0.0"
 
     def encrypt(self, text, recv_key, template, session_key_type, xpath=""):
         """
@@ -834,7 +841,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
         except XmlsecError as e:
             raise SignatureError(com_list) from e
 
-        return parse_xmlsec_verify_output(self.vsn, stderr)
+        return parse_xmlsec_verify_output(stderr, self.version_nums)
 
     def _run_xmlsec(self, com_list, extra_args):
         """
@@ -846,7 +853,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
         """
         with NamedTemporaryFile(suffix=".xml") as ntf:
             com_list.extend(["--output", ntf.name])
-            if self.vsn >= (1, 3):
+            if self.version_nums >= (1, 3):
                 com_list.extend(['--lax-key-search'])
             com_list += extra_args
 
@@ -882,10 +889,13 @@ class CryptoBackendXMLSecurity(CryptoBackend):
     def __init__(self):
         CryptoBackend.__init__(self)
 
+    @property
     def version(self):
-        # XXX if XMLSecurity.__init__ included a __version__, that would be
-        # better than static 0.0 here.
-        return "XMLSecurity 0.0"
+        try:
+            import xmlsec
+            return xmlsec.__version__
+        except (ImportError, AttributeError):
+            return "0.0.0"
 
     def sign_statement(self, statement, node_name, key_file, node_id):
         """

--- a/tests/test_40_sigver.py
+++ b/tests/test_40_sigver.py
@@ -192,7 +192,7 @@ class TestSecurity:
         assert sass.id == "id-11111"
         assert time_util.str_to_time(sass.issue_instant)
 
-        print(f"Crypto version : {self.sec.crypto.version()}")
+        print(f"Crypto version : {self.sec.crypto.version}")
 
         item = self.sec.check_signature(sass, class_name(sass), sign_ass)
 
@@ -209,7 +209,7 @@ class TestSecurity:
         assert sass.id == "id-11111"
         assert time_util.str_to_time(sass.issue_instant)
 
-        print(f"Crypto version : {self.sec.crypto.version()}")
+        print(f"Crypto version : {self.sec.crypto.version}")
 
         item = self.sec.check_signature(sass, class_name(sass), sign_ass, must=True)
 
@@ -498,7 +498,7 @@ class TestSecurityNonAsciiAva:
         assert sass.id == "id-11111"
         assert time_util.str_to_time(sass.issue_instant)
 
-        print(f"Crypto version : {self.sec.crypto.version()}")
+        print(f"Crypto version : {self.sec.crypto.version}")
 
         item = self.sec.check_signature(sass, class_name(sass), sign_ass)
 
@@ -515,7 +515,7 @@ class TestSecurityNonAsciiAva:
         assert sass.id == "id-11111"
         assert time_util.str_to_time(sass.issue_instant)
 
-        print(f"Crypto version : {self.sec.crypto.version()}")
+        print(f"Crypto version : {self.sec.crypto.version}")
 
         item = self.sec.check_signature(sass, class_name(sass), sign_ass, must=True)
 
@@ -1079,18 +1079,34 @@ def test_sha256_signing_non_ascii_ava():
 
 def test_xmlsec_output_line_parsing():
     output1 = "prefix\nOK\npostfix"
-    assert sigver.parse_xmlsec_output(output1)
+    assert sigver.parse_xmlsec_verify_output(output1)
 
     output2 = "prefix\nFAIL\npostfix"
     with raises(sigver.XmlsecError):
-        sigver.parse_xmlsec_output(output2)
+        sigver.parse_xmlsec_verify_output(output2)
 
     output3 = "prefix\r\nOK\r\npostfix"
-    assert sigver.parse_xmlsec_output(output3)
+    assert sigver.parse_xmlsec_verify_output(output3)
 
     output4 = "prefix\r\nFAIL\r\npostfix"
     with raises(sigver.XmlsecError):
-        sigver.parse_xmlsec_output(output4)
+        sigver.parse_xmlsec_verify_output(output4)
+
+
+def test_xmlsec_v1_3_x_output_line_parsing():
+    output1 = "prefix\nVerification status: OK\npostfix"
+    assert sigver.parse_xmlsec_verify_output(output1, version=(1, 3))
+
+    output2 = "prefix\nVerification status: FAILED\npostfix"
+    with raises(sigver.XmlsecError):
+        sigver.parse_xmlsec_verify_output(output2, version=(1, 3))
+
+    output3 = "prefix\r\nVerification status: OK\r\npostfix"
+    assert sigver.parse_xmlsec_verify_output(output3, version=(1, 3))
+
+    output4 = "prefix\r\nVerification status: FAILED\r\npostfix"
+    with raises(sigver.XmlsecError):
+        sigver.parse_xmlsec_verify_output(output4, version=(1, 3))
 
 
 def test_cert_trailing_newlines_ignored():


### PR DESCRIPTION
### Description

Add support for xmlsec1 1.3

##### The feature or problem addressed by this PR

There are two changes in xmlsec1 1.3 that break compatibility for me:

1. From xmlsec repo: 

> (API breaking change) Changed the key search to strict mode: only keys referenced by KeyInfo are used. To restore the old "lax" mode, set XMLSEC_KEYINFO_FLAGS_LAX_KEY_SEARCH flag on xmlSecKeyInfoCtx or use '--lax-key-search' option for XMLSec command line utility.

I couldn't make it work without passing `--lax-key-search` to xmlsec1, 'cause in my case it seems like KeyInfo never contains the private key that is used for signature.
Please let me know if you have a better solution.

2. xmlsec1 changed format of the output for signature verification: "OK" -> "Verification status: OK" 

##### What your changes do and why you chose this solution

I am checking the version of the xmlsec1 utility and if it is > 1.3, I am (a) adding the `--lax-key-search` param; (b) expect proper output during signature verification.

### Checklist 

* [x] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [x] Updated documentation OR the change is too minor to be documented
* [x] Updated CHANGELOG.md OR changes are insignificant
