### PR TITLE
Don't let create_metadata_string miss the crypto_backend setting

### DIFF
--- a/src/saml2/metadata.py
+++ b/src/saml2/metadata.py
@@ -106,6 +106,7 @@ def create_metadata_string(
     conf.key_file = config.key_file or keyfile
     conf.cert_file = config.cert_file or cert
     conf.xmlsec_binary = config.xmlsec_binary
+    conf.crypto_backend = config.crypto_backend
     secc = security_context(conf)
 
     sign_alg = sign_alg or config.signing_algorithm


### PR DESCRIPTION
### Description

Pass crypto_backend to security_context() in create_metadata_string

##### The feature or problem addressed by this PR

create_metadata_string uses xmlsec1 unconditionally. Even when crypto_backend is set to XMLsecurity.

##### What your changes do and why you chose this solution

My changes passes the crypto_backend from the config param, to the config that is used from creation of security_context.

### Checklist

* [x] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [x] Updated documentation OR the change is too minor to be documented
* [x] Updated CHANGELOG.md OR changes are insignificant
