### PR TITLE
Remove utility from packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 packages = [
     { include = "saml2", from = "src" },
     { include = "saml2test", from = "src" },
-    { include = "utility", from = "src" },
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
### Description
This fixes #899.


##### The feature or problem addressed by this PR

When packaging saml2 downstream with pyproject RPM macros, the utility module is installed. This might clash with other modules.


### Checklist

* [x] Checked that no other issues or pull requests exist for the same issue/change
* [x] Added tests covering the new functionality
* [x] Updated documentation OR the change is too minor to be documented
* [x] Updated CHANGELOG.md OR changes are insignificant
