### PR TITLE
feat: configurable encryption algorithm types

### DIFF
--- a/docs/howto/config.rst
+++ b/docs/howto/config.rst
@@ -656,6 +656,42 @@ Example::
 
     "verify_encrypt_cert_assertion": verify_encrypt_cert
 
+encrypt_assertion_session_key_algs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+List of block encryption algorithms which can be used to encrypt assertion.
+Values order is from highest to lowest priority. Default value is ["http://www.w3.org/2001/04/xmlenc#tripledes-cbc"]
+
+Valid values are:
+    - "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"
+    - "http://www.w3.org/2001/04/xmlenc#aes128-cbc"
+    - "http://www.w3.org/2001/04/xmlenc#aes192-cbc"
+    - "http://www.w3.org/2001/04/xmlenc#aes256-cbc"
+    - "http://www.w3.org/2009/xmlenc11#aes128-gcm"
+    - "http://www.w3.org/2009/xmlenc11#aes192-gcm"
+    - "http://www.w3.org/2009/xmlenc11#aes256-gcm"
+
+Example::
+
+    "encrypt_assertion_session_key_algs" : [
+        "http://www.w3.org/2009/xmlenc11#aes256-gcm",
+        "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"
+    ]
+
+encrypt_assertion_cert_key_algs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+List of key transport algorithms which can be used to encrypt session key used to encrypting assertion.
+Values order is from highest to lowest priority. Default value is ["http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"]
+
+Valid values are:
+    - "http://www.w3.org/2001/04/xmlenc#rsa-1_5"
+    - "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"
+
+Example::
+
+    "encrypt_assertion_cert_key_algs": [
+        "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p",
+        "http://www.w3.org/2001/04/xmlenc#rsa-1_5"
+    ]
 
 Specific directives
 -------------------

--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -76,6 +76,8 @@ COMMON_ARGS = [
     "signing_algorithm",
     "digest_algorithm",
     "http_client_timeout",
+    "encrypt_assertion_session_key_algs",
+    "encrypt_assertion_cert_key_algs",
 ]
 
 SP_ARGS = [
@@ -229,6 +231,8 @@ class Config:
         self.signing_algorithm = None
         self.digest_algorithm = None
         self.http_client_timeout = None
+        self.encrypt_assertion_session_key_algs = ["http://www.w3.org/2001/04/xmlenc#tripledes-cbc"]
+        self.encrypt_assertion_cert_key_algs = ["http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"]
 
     def setattr(self, context, attr, val):
         if context == "":

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -60,7 +60,7 @@ from saml2.samlp import NameIDMappingRequest
 from saml2.samlp import SessionIndex
 from saml2.samlp import artifact_resolve_from_string
 from saml2.samlp import response_from_string
-from saml2.sigver import SignatureError
+from saml2.sigver import SignatureError, XMLSEC_SESSION_KEY_URI_TO_ALG
 from saml2.sigver import SigverError
 from saml2.sigver import get_pem_wrapped_unwrapped
 from saml2.sigver import make_temp
@@ -77,7 +77,6 @@ from saml2.virtual_org import VirtualOrg
 from saml2.xmldsig import DIGEST_ALLOWED_ALG
 from saml2.xmldsig import SIG_ALLOWED_ALG
 from saml2.xmldsig import DefaultSignature
-
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +179,9 @@ class Entity(HTTPBase):
         self.debug = self.config.debug
 
         self.sec = security_context(self.config)
+
+        self.encrypt_assertion_session_key_algs = self.config.encrypt_assertion_session_key_algs
+        self.encrypt_assertion_cert_key_algs = self.config.encrypt_assertion_cert_key_algs
 
         if virtual_organization:
             if isinstance(virtual_organization, str):
@@ -644,23 +646,52 @@ class Entity(HTTPBase):
                 return True
         return False
 
-    def _encrypt_assertion(self, encrypt_cert, sp_entity_id, response, node_xpath=None):
+    def _encrypt_assertion(
+        self,
+        encrypt_cert,
+        sp_entity_id,
+        response,
+        node_xpath=None,
+        encrypt_cert_session_key_alg=None,
+        encrypt_cert_cert_key_alg=None,
+    ):
         """Encryption of assertions.
 
         :param encrypt_cert: Certificate to be used for encryption.
         :param sp_entity_id: Entity ID for the calling service provider.
         :param response: A samlp.Response
+        :param encrypt_cert_cert_key_alg: algorithm used for encrypting session key
+        :param encrypt_cert_session_key_alg: algorithm used for encrypting assertion
+        :param encrypt_cert_cert_key_alg:
         :param node_xpath: Unquie path to the element to be encrypted.
         :return: A new samlp.Resonse with the designated assertion encrypted.
         """
         _certs = []
 
         if encrypt_cert:
-            _certs.append((None, encrypt_cert))
+            _certs.append((None, encrypt_cert, None, None))
         elif sp_entity_id is not None:
-            _certs = self.metadata.certs(sp_entity_id, "any", "encryption")
+            _certs = self.metadata.certs(sp_entity_id, "any", "encryption", get_with_usage_and_encryption_methods=True)
         exception = None
-        for _cert_name, _cert in _certs:
+
+        # take certs with encryption and encryption_methods first (priority 1)
+        sorted_certs = []
+        for _unpacked_cert in _certs:
+            _cert_name, _cert, _cert_use, _cert_encryption_methods = _unpacked_cert
+            if _cert_use == "encryption" and _cert_encryption_methods:
+                sorted_certs.append(_unpacked_cert)
+
+        # take certs with encryption or encryption_methods (priority 2)
+        for _unpacked_cert in _certs:
+            _cert_name, _cert, _cert_use, _cert_encryption_methods = _unpacked_cert
+            if _cert_use == "encryption" and _unpacked_cert not in sorted_certs:
+                sorted_certs.append(_unpacked_cert)
+
+        for _unpacked_cert in _certs:
+            if _unpacked_cert not in sorted_certs:
+                sorted_certs.append(_unpacked_cert)
+
+        for _cert_name, _cert, _cert_use, _cert_encryption_methods in sorted_certs:
             wrapped_cert, unwrapped_cert = get_pem_wrapped_unwrapped(_cert)
             try:
                 tmp = make_temp(
@@ -668,10 +699,44 @@ class Entity(HTTPBase):
                     decode=False,
                     delete_tmpfiles=self.config.delete_tmpfiles,
                 )
+
+                msg_enc = (
+                    encrypt_cert_session_key_alg
+                    if encrypt_cert_session_key_alg
+                    else self.encrypt_assertion_session_key_algs[0]
+                )
+                key_enc = (
+                    encrypt_cert_cert_key_alg if encrypt_cert_cert_key_alg else self.encrypt_assertion_cert_key_algs[0]
+                )
+
+                if encrypt_cert != _cert and _cert_encryption_methods:
+                    viable_session_key_algs = []
+                    for alg in self.encrypt_assertion_session_key_algs:
+                        for cert_method in _cert_encryption_methods:
+                            if cert_method.get("algorithm") == alg:
+                                viable_session_key_algs.append(alg)
+
+                    viable_cert_algs = []
+                    for alg in self.encrypt_assertion_cert_key_algs:
+                        for cert_method in _cert_encryption_methods:
+                            if cert_method.get("algorithm") == alg:
+                                viable_cert_algs.append(alg)
+
+                    if viable_session_key_algs:
+                        msg_enc = viable_session_key_algs[0]
+
+                    if viable_cert_algs:
+                        key_enc = viable_cert_algs[0]
+
+                key_type = XMLSEC_SESSION_KEY_URI_TO_ALG.get(msg_enc)
+
                 response = self.sec.encrypt_assertion(
                     response,
                     tmp.name,
-                    pre_encryption_part(key_name=_cert_name, encrypt_cert=unwrapped_cert),
+                    pre_encryption_part(
+                        key_name=_cert_name, encrypt_cert=unwrapped_cert, msg_enc=msg_enc, key_enc=key_enc
+                    ),
+                    key_type=key_type,
                     node_xpath=node_xpath,
                 )
                 return response
@@ -697,7 +762,11 @@ class Entity(HTTPBase):
         encrypt_assertion_self_contained=False,
         encrypted_advice_attributes=False,
         encrypt_cert_advice=None,
+        encrypt_cert_advice_cert_key_alg=None,
+        encrypt_cert_advice_session_key_alg=None,
         encrypt_cert_assertion=None,
+        encrypt_cert_assertion_cert_key_alg=None,
+        encrypt_cert_assertion_session_key_alg=None,
         sign_assertion=None,
         pefim=False,
         sign_alg=None,
@@ -731,8 +800,16 @@ class Entity(HTTPBase):
         element should be encrypted.
         :param encrypt_cert_advice: Certificate to be used for encryption of
         assertions in the advice element.
+        :param encrypt_cert_advice_cert_key_alg: algorithm used for encrypting session key
+        by encrypt_cert_advice
+        :param encrypt_cert_advice_session_key_alg: algorithm used for encrypting assertion
+        when using encrypt_cert_advice
         :param encrypt_cert_assertion: Certificate to be used for encryption
         of assertions.
+        :param encrypt_cert_assertion_cert_key_alg: algorithm used for encrypting session key
+        by encrypt_cert_assertion
+        :param encrypt_cert_assertion_session_key_alg: algorithm used for encrypting assertion when
+        using encrypt_cert_assertion
         :param sign_assertion: True if assertions should be signed.
         :param pefim: True if a response according to the PEFIM profile
         should be created.
@@ -856,6 +933,8 @@ class Entity(HTTPBase):
                             sp_entity_id,
                             response,
                             node_xpath=node_xpath,
+                            encrypt_cert_session_key_alg=encrypt_cert_advice_session_key_alg,
+                            encrypt_cert_cert_key_alg=encrypt_cert_advice_cert_key_alg,
                         )
                         response = response_from_string(response)
 
@@ -900,7 +979,13 @@ class Entity(HTTPBase):
                     response = signed_instance_factory(response, self.sec, to_sign_assertion)
 
                 # XXX encrypt assertion
-                response = self._encrypt_assertion(encrypt_cert_assertion, sp_entity_id, response)
+                response = self._encrypt_assertion(
+                    encrypt_cert_assertion,
+                    sp_entity_id,
+                    response,
+                    encrypt_cert_session_key_alg=encrypt_cert_assertion_session_key_alg,
+                    encrypt_cert_cert_key_alg=encrypt_cert_assertion_cert_key_alg,
+                )
             else:
                 # XXX sign other parts! (defiend by to_sign)
                 if to_sign:
@@ -1357,7 +1442,6 @@ class Entity(HTTPBase):
         digest_alg=None,
         **kwargs,
     ):
-
         rinfo = self.response_args(request, bindings)
 
         response = self._status_response(

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -476,7 +476,7 @@ class MetaData:
 
         return True
 
-    def certs(self, entity_id, descriptor, use="signing"):
+    def certs(self, entity_id, descriptor, use="signing", get_with_usage_and_encryption_methods=False):
         """
         Returns certificates for the given Entity
         """
@@ -494,7 +494,10 @@ class MetaData:
                         for dat in key_info["x509_data"]:
                             cert = repack_cert(dat["x509_certificate"]["text"])
                             if cert not in res:
-                                res.append((key_name_txt, cert))
+                                if get_with_usage_and_encryption_methods:
+                                    res.append((key_name_txt, cert, key_use, key.get("encryption_method")))
+                                else:
+                                    res.append((key_name_txt, cert))
 
             return res
 
@@ -1327,7 +1330,7 @@ class MetadataStore(MetaData):
                     "name_format": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
                     "friendly_name": "subject-id",
                     "is_required": "true",
-                }
+                },
             ]
         elif subject_id_req == "pairwise-id":
             return [

--- a/src/saml2/server.py
+++ b/src/saml2/server.py
@@ -457,7 +457,11 @@ class Server(Entity):
         best_effort=False,
         encrypt_assertion=False,
         encrypt_cert_advice=None,
+        encrypt_cert_advice_cert_key_alg=None,
+        encrypt_cert_advice_session_key_alg=None,
         encrypt_cert_assertion=None,
+        encrypt_cert_assertion_cert_key_alg=None,
+        encrypt_cert_assertion_session_key_alg=None,
         authn_statement=None,
         encrypt_assertion_self_contained=False,
         encrypted_advice_attributes=False,
@@ -492,8 +496,16 @@ class Server(Entity):
         element should be encrypted.
         :param encrypt_cert_advice: Certificate to be used for encryption of
         assertions in the advice element.
+        :param encrypt_cert_advice_cert_key_alg: algorithm used for encrypting session key
+        by encrypt_cert_advice
+        :param encrypt_cert_advice_session_key_alg: algorithm used for encrypting assertion
+        when using encrypt_cert_advice
         :param encrypt_cert_assertion: Certificate to be used for encryption
         of assertions.
+        :param encrypt_cert_assertion_cert_key_alg: algorithm used for encrypting session key
+        by encrypt_cert_assertion
+        :param encrypt_cert_assertion_session_key_alg: algorithm used for encrypting assertion when
+        using encrypt_cert_assertion
         :param authn_statement: Authentication statement.
         :param pefim: True if a response according to the PEFIM profile
         should be created.
@@ -598,7 +610,11 @@ class Server(Entity):
             sp_entity_id=sp_entity_id,
             encrypt_assertion=encrypt_assertion,
             encrypt_cert_advice=encrypt_cert_advice,
+            encrypt_cert_advice_cert_key_alg=encrypt_cert_advice_cert_key_alg,
+            encrypt_cert_advice_session_key_alg=encrypt_cert_advice_session_key_alg,
             encrypt_cert_assertion=encrypt_cert_assertion,
+            encrypt_cert_assertion_cert_key_alg=encrypt_cert_assertion_cert_key_alg,
+            encrypt_cert_assertion_session_key_alg=encrypt_cert_assertion_session_key_alg,
             encrypt_assertion_self_contained=encrypt_assertion_self_contained,
             encrypted_advice_attributes=encrypted_advice_attributes,
             sign_assertion=sign_assertion,
@@ -724,7 +740,6 @@ class Server(Entity):
             ("encrypted_advice_attributes", "verify_encrypt_cert_advice", "encrypt_cert_advice", kwargs["pefim"]),
             ("encrypt_assertion", "verify_encrypt_cert_assertion", "encrypt_cert_assertion", False),
         ]:
-
             if args[arg] or pefim:
                 _enc_cert = self.config.getattr(attr, "idp")
 
@@ -789,7 +804,11 @@ class Server(Entity):
         sign_response=None,
         sign_assertion=None,
         encrypt_cert_advice=None,
+        encrypt_cert_advice_cert_key_alg=None,
+        encrypt_cert_advice_session_key_alg=None,
         encrypt_cert_assertion=None,
+        encrypt_cert_assertion_cert_key_alg=None,
+        encrypt_cert_assertion_session_key_alg=None,
         encrypt_assertion=None,
         encrypt_assertion_self_contained=True,
         encrypted_advice_attributes=False,
@@ -822,8 +841,16 @@ class Server(Entity):
         element should be encrypted.
         :param encrypt_cert_advice: Certificate to be used for encryption of
         assertions in the advice element.
+        :param encrypt_cert_advice_cert_key_alg: algorithm used for encrypting session key
+        by encrypt_cert_advice
+        :param encrypt_cert_advice_session_key_alg: algorithm used for encrypting assertion
+        when using encrypt_cert_advice
         :param encrypt_cert_assertion: Certificate to be used for encryption
         of assertions.
+        :param encrypt_cert_assertion_cert_key_alg: algorithm used for encrypting session key
+        by encrypt_cert_assertion
+        :param encrypt_cert_assertion_session_key_alg: algorithm used for encrypting assertion when
+        using encrypt_cert_assertion
         :param pefim: True if a response according to the PEFIM profile
         should be created.
         :return: A response instance
@@ -869,6 +896,10 @@ class Server(Entity):
                 sign_alg=sign_alg,
                 digest_alg=digest_alg,
                 session_not_on_or_after=session_not_on_or_after,
+                encrypt_cert_advice_cert_key_alg=encrypt_cert_advice_cert_key_alg,
+                encrypt_cert_advice_session_key_alg=encrypt_cert_advice_session_key_alg,
+                encrypt_cert_assertion_cert_key_alg=encrypt_cert_assertion_cert_key_alg,
+                encrypt_cert_assertion_session_key_alg=encrypt_cert_assertion_session_key_alg,
                 **args,
             )
         except MissingValue as exc:
@@ -1054,7 +1085,6 @@ class Server(Entity):
         digest_alg=None,
         **kwargs,
     ):
-
         # ----------------------------------------
         # <ecp:Response
         # ----------------------------------------

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -77,6 +77,16 @@ RSA_1_5 = "http://www.w3.org/2001/04/xmlenc#rsa-1_5"
 TRIPLE_DES_CBC = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"
 RSA_OAEP_MGF1P = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"
 
+XMLSEC_SESSION_KEY_URI_TO_ALG = {
+    "http://www.w3.org/2001/04/xmlenc#tripledes-cbc": "des-192",
+    "http://www.w3.org/2001/04/xmlenc#aes128-cbc": "aes-128",
+    "http://www.w3.org/2001/04/xmlenc#aes192-cbc": "aes-192",
+    "http://www.w3.org/2001/04/xmlenc#aes256-cbc": "aes-256",
+    "http://www.w3.org/2009/xmlenc11#aes128-gcm": "aes-128",
+    "http://www.w3.org/2009/xmlenc11#aes192-gcm": "aes-192",
+    "http://www.w3.org/2009/xmlenc11#aes256-gcm": "aes-256",
+}
+
 
 class SigverError(SAMLError):
     pass
@@ -327,7 +337,7 @@ def signed_instance_factory(instance, seccont, elements_to_sign=None):
     if not isinstance(instance, str):
         signed_xml = instance.to_string()
 
-    for (node_name, nodeid) in elements_to_sign:
+    for node_name, nodeid in elements_to_sign:
         signed_xml = seccont.sign_statement(signed_xml, node_name=node_name, node_id=nodeid)
 
     return signed_xml
@@ -486,9 +496,9 @@ def parse_xmlsec_verify_output(output, version=None):
                 raise XmlsecError(output)
     else:
         for line in output.splitlines():
-            if line == 'Verification status: OK':
+            if line == "Verification status: OK":
                 return True
-            elif line == 'Verification status: FAILED':
+            elif line == "Verification status: FAILED":
                 raise XmlsecError(output)
     raise XmlsecError(output)
 
@@ -854,7 +864,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
         with NamedTemporaryFile(suffix=".xml") as ntf:
             com_list.extend(["--output", ntf.name])
             if self.version_nums >= (1, 3):
-                com_list.extend(['--lax-key-search'])
+                com_list.extend(["--lax-key-search"])
             com_list += extra_args
 
             logger.debug("xmlsec command: %s", " ".join(com_list))
@@ -1206,7 +1216,6 @@ class SecurityContext:
         sec_backend=None,
         delete_tmpfiles=True,
     ):
-
         if not isinstance(crypto, CryptoBackend):
             raise ValueError("crypto should be of type CryptoBackend")
         self.crypto = crypto
@@ -1733,7 +1742,7 @@ class SecurityContext:
         :param key_file: A file that contains the key to be used
         :return: A possibly multiple signed statement
         """
-        for (item, sid) in to_sign:
+        for item, sid in to_sign:
             if not sid:
                 if not item.id:
                     sid = item.id = sid()


### PR DESCRIPTION
### Description


##### The feature or problem addressed by this PR

Encrypt assertion session key and transport key were hardcoded.

closes: #821 


##### What your changes do and why you chose this solution

Added `encrypt_assertion_session_key_algs` and `encrypt_assertion_cert_key_algs` configuration options to specify algorithms which can be used for encrypting assertions. Both of them are lists and index represents algorithm priority (first one has highest priority).

When there is not cert prvided in parameters program will try to find one in metadata. Keys in metadata are prioritized in following order.
* with `use=encryption` and specified `EncryptionMethods`
* with `use=encryption`
* without `use=encryption`

If key has `EncryptionMethods` program will make intersect with configuration options and will take algorithms by its priority. If intersect is empty or there is not `EncryptionMethod` program will use first ones from config options.

Added paramters and their propagation to `Server.create_authn_response` specifying session key and transport key algorithms for `encrypt_cert_advice` and `encrypt_cert_assertion`. If they are not provided program will use first ones from new config options.

For support `http://www.w3.org/2009/xmlenc11#rsa-oaep` transport key alg with `MGF1` more changes and `xmlsec version>=1.3.0` will be needed.


### Checklist

* [x] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [x] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
