### PR TITLE
Use class delete_tmpfiles flag in _run_xmlsec

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -851,7 +851,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
             key-value parameters
         :result: Whatever xmlsec wrote to an --output temporary file
         """
-        with NamedTemporaryFile(suffix=".xml") as ntf:
+        with NamedTemporaryFile(suffix=".xml", delete=self.delete_tmpfiles) as ntf:
             com_list.extend(["--output", ntf.name])
             if self.version_nums >= (1, 3):
                 com_list.extend(['--lax-key-search'])


### PR DESCRIPTION
### Description
Fixes issue of not deleting temporary files in windows to support running xmlsec1 as a subprocess in windows.

##### What your changes do and why you chose this solution

With this PR it is possible to use config parameter "delete_tmpfiles": False if os.name == 'nt' else True

#863

