### PR TITLE
Correct make_metadata.py path

### DIFF
--- a/example/all.sh
+++ b/example/all.sh
@@ -8,13 +8,13 @@ startme() {
     if [ ! -f service_conf.py ] ; then
         cp service_conf.py.example service_conf.py
     fi
-    ../../tools/make_metadata.py sp_conf > sp.xml
+    ../../src/saml2/tools/make_metadata.py sp_conf > sp.xml
 
     cd ../idp2
     if [ ! -f idp_conf.py ] ; then
         cp idp_conf.py.example idp_conf.py
     fi
-    ../../tools/make_metadata.py idp_conf > idp.xml
+    ../../src/saml2/tools/make_metadata.py idp_conf > idp.xml
 
     cd ../sp-wsgi
     ./sp.py sp_conf &


### PR DESCRIPTION
### Description

##### The feature or problem addressed by this PR

Related to issue #915 
Example script has wrong path to the tools directory.

##### What your changes do and why you chose this solution

Just fixed the path.

### Checklist

* [x] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [x] Updated documentation OR the change is too minor to be documented
* [x] Updated CHANGELOG.md OR changes are insignificant
