### PR TITLE
Fix deprecation warning for datetime.datetime.utcnow

### DIFF
--- a/src/saml2/time_util.py
+++ b/src/saml2/time_util.py
@@ -8,6 +8,7 @@ different types of information.
 import calendar
 from datetime import datetime
 from datetime import timedelta
+from datetime import UTC
 import re
 import sys
 import time
@@ -175,7 +176,7 @@ def time_in_a_while(days=0, seconds=0, microseconds=0, milliseconds=0, minutes=0
     :return: UTC time
     """
     delta = timedelta(days, seconds, microseconds, milliseconds, minutes, hours, weeks)
-    return datetime.utcnow() + delta
+    return datetime.now(UTC) + delta
 
 
 def time_a_while_ago(days=0, seconds=0, microseconds=0, milliseconds=0, minutes=0, hours=0, weeks=0):
@@ -185,7 +186,7 @@ def time_a_while_ago(days=0, seconds=0, microseconds=0, milliseconds=0, minutes=
                     minutes[, hours[, weeks]]]]]]])
     """
     delta = timedelta(days, seconds, microseconds, milliseconds, minutes, hours, weeks)
-    return datetime.utcnow() - delta
+    return datetime.now(UTC) - delta
 
 
 def in_a_while(days=0, seconds=0, microseconds=0, milliseconds=0, minutes=0, hours=0, weeks=0, format=TIME_FORMAT):

--- a/tests/test_41_response.py
+++ b/tests/test_41_response.py
@@ -127,7 +127,7 @@ class TestResponse:
     @patch("saml2.time_util.datetime")
     def test_false_sign(self, mock_datetime, caplog):
         caplog.set_level(logging.ERROR)
-        mock_datetime.utcnow = Mock(return_value=datetime.datetime(2016, 9, 4, 9, 59, 39))
+        mock_datetime.now = Mock(return_value=datetime.datetime(2016, 9, 4, 9, 59, 39))
         with open(FALSE_ASSERT_SIGNED) as fp:
             xml_response = fp.read()
 


### PR DESCRIPTION
Fixes #934


### Description

Since Python 3.12, the `utcnow` function is deprecated - see, https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

This commit turns usages of `utcnow()` into `now(UTC)`.


##### The feature or problem addressed by this PR

This addresses the issue described in #934 


##### What your changes do and why you chose this solution

The solution is based on the suggestion from official Python docs:
https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

### Checklist

* [ ] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [ ] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
