### PR TITLE
add norEduPersonLegalName to Swamid entity categories CoCo v1 and v2

### DIFF
--- a/src/saml2/entity_category/swamid.py
+++ b/src/saml2/entity_category/swamid.py
@@ -44,6 +44,7 @@ GEANT_COCO = [
     "cn",
     "givenName",
     "sn",
+    "norEduPersonLegalName",
     "eduPersonAssurance",
     "eduPersonScopedAffiliation",
     "eduPersonAffiliation",


### PR DESCRIPTION
### Description
Add norEduPersonLegalName to Swamid entity categories CoCo v1 and v2.

### Checklist

* [X] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [X] Updated documentation OR the change is too minor to be documented
* [X] Updated CHANGELOG.md OR changes are insignificant
