### PR TITLE
allow MDQ "entity_transform": "percent_encoded"

### DIFF
--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -1,3 +1,4 @@
+import urllib.parse
 import hashlib
 from hashlib import sha1
 import importlib
@@ -903,6 +904,10 @@ class MetaDataMDX(InMemoryMetaData):
         transform = f"{{sha1}}{entity_id_sha1}"
         return transform
 
+    @staticmethod
+    def percent_encoded_entity_transform(entity_id):
+        return urllib.parse.quote(entity_id, safe='')
+
     def __init__(
         self,
         url=None,
@@ -932,7 +937,9 @@ class MetaDataMDX(InMemoryMetaData):
 
         self.url = url.rstrip("/")
 
-        if entity_transform:
+        if entity_transform == "percent_encoded":
+            self.entity_transform = MetaDataMDX.percent_encoded_entity_transform
+        elif entity_transform:
             self.entity_transform = entity_transform
         else:
             self.entity_transform = MetaDataMDX.sha1_entity_transform


### PR DESCRIPTION

### Description

##### The feature or problem addressed by this PR

MDQ always uses sha1 entityId encoding, but some MDQ server only handle percent-encoding

https://github.com/IdentityPython/SATOSA/issues/460

Then change allows to behave alike Shibboleth SP using `mdq.entity_transform` to "percent_encoded"

##### What your changes do and why you chose this solution

NB : the change introduces a mix of types for param `entity_transform`: it was expecting a function or None. The change adds the possibility to handle string "percent_encoded". I don't enough about the code to know if that's ok...