### PR TITLE
fix typo: add missing "e"

### DIFF
--- a/docs/examples/idp.rst
+++ b/docs/examples/idp.rst
@@ -1,6 +1,6 @@
 .. _example_idp:
 
-An extremly simple example of a SAML2 identity provider.
+An extremely simple example of a SAML2 identity provider.
 ========================================================
 
 There are 2 example IDPs in the project's example directory:


### PR DESCRIPTION
### Description

just fix a typo in the document.

### Checklist

* [x] Checked that no other issues or pull requests exist for the same issue/change
* [x] Added tests covering the new functionality
* [x] Updated documentation OR the change is too minor to be documented
* [x] Updated CHANGELOG.md OR changes are insignificant
