### PR TITLE
Zlib error not being catch on inner exception try-catch of entity.py

### DIFF
--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -3,7 +3,6 @@ from binascii import hexlify
 import copy
 from hashlib import sha1
 import logging
-import zlib
 
 import requests
 
@@ -42,6 +41,7 @@ from saml2.s_utils import error_status_factory
 from saml2.s_utils import rndbytes
 from saml2.s_utils import sid
 from saml2.s_utils import success_status_factory
+from saml2.s_utils import zlib_error
 from saml2.saml import NAMEID_FORMAT_ENTITY
 from saml2.saml import EncryptedAssertion
 from saml2.saml import Issuer
@@ -447,7 +447,7 @@ class Entity(HTTPBase):
             elif binding == BINDING_HTTP_POST:
                 try:
                     xmlstr = decode_base64_and_inflate(txt)
-                except zlib.error:
+                except zlib_error:
                     xmlstr = base64.b64decode(txt)
             elif binding == BINDING_SOAP:
                 func = getattr(soap, f"parse_soap_enveloped_saml_{msgtype}")

--- a/src/saml2/s_utils.py
+++ b/src/saml2/s_utils.py
@@ -75,6 +75,9 @@ class UnravelError(Exception):
     pass
 
 
+zlib_error = zlib.error
+
+
 EXCEPTION2STATUS = {
     VersionMismatch: samlp.STATUS_VERSION_MISMATCH,
     UnknownPrincipal: samlp.STATUS_UNKNOWN_PRINCIPAL,


### PR DESCRIPTION
### Description

##### The feature or problem addressed by this PR

For some reason, zlib.error is not being catch on the inner try-catch on entity.py and resolve to UnravelError on the outer exception (supposedly it has to run base64.b64decode silently after error?), if I import zlib from s_utils.py then the try-catch works properly. Not sure if is just me, or is a bug ? I run this in python 3.11.9, pysaml2 7.5.0

```
# entity.py - def unravel
...
try:
    if binding == BINDING_HTTP_REDIRECT:
        xmlstr = decode_base64_and_inflate(txt)
    elif binding == BINDING_HTTP_POST:
        try:
            xmlstr = decode_base64_and_inflate(txt)
        except zlib.error: # supposedly to error here? but is not for some reason, i tried type(e) clearly shows zlib.error
            xmlstr = base64.b64decode(txt)
    elif binding == BINDING_SOAP:
        func = getattr(soap, f"parse_soap_enveloped_saml_{msgtype}")
        xmlstr = func(txt)
    elif binding == BINDING_HTTP_ARTIFACT:
        xmlstr = base64.b64decode(txt)
    else:
        xmlstr = txt
except Exception: # being caught here instead
    raise UnravelError(f"Unravelling binding '{binding}' failed")
...
```

##### What your changes do and why you chose this solution

<!-- description of the technical changes that help resolve the issue -->

Could replicate as below, where we raise the error directly, and is supposed to catch by the inner try-catch in entity.py and run base64.b64decode.

```
# s_utils.py
def decode_base64_and_inflate(string):
    """base64 decodes and then inflates according to RFC1951

    :param string: a deflated and encoded string
    :return: the string after decoding and inflating
    """
    raise zlib.error('test')
    return zlib.decompress(base64.b64decode(string), -15)
```

### Checklist

* [ ] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [ ] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
