### PR TITLE
Add xenc-schema-11.xsd

### DIFF
--- a/src/saml2/data/schemas/xenc-schema-11.xsd
+++ b/src/saml2/data/schemas/xenc-schema-11.xsd
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+#
+# Copyright ©[2011] World Wide Web Consortium
+# (Massachusetts Institute of Technology,
+#  European Research Consortium for Informatics and Mathematics,
+#  Keio University). All Rights Reserved.
+# This work is distributed under the W3C® Software License [1] in the
+# hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.
+# [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+#
+-->
+
+<!DOCTYPE schema  PUBLIC "-//W3C//DTD XMLSchema 200102//EN"
+ "http://www.w3.org/2001/XMLSchema.dtd"
+ [
+	<!ATTLIST schema
+     xmlns:xenc CDATA #FIXED 'http://www.w3.org/2001/04/xmlenc#'
+     xmlns:ds CDATA #FIXED 'http://www.w3.org/2000/09/xmldsig#'
+     xmlns:xenc11 CDATA #FIXED 'http://www.w3.org/2009/xmlenc11#'>
+	<!ENTITY xenc 'http://www.w3.org/2001/04/xmlenc#'>
+	<!ENTITY % p ''>
+	<!ENTITY % s ''>
+]>
+
+<schema xmlns='http://www.w3.org/2001/XMLSchema' version='1.0'
+        xmlns:xenc='http://www.w3.org/2001/04/xmlenc#'
+        xmlns:xenc11='http://www.w3.org/2009/xmlenc11#'
+        xmlns:ds='http://www.w3.org/2000/09/xmldsig#'
+        targetNamespace='http://www.w3.org/2009/xmlenc11#'
+        elementFormDefault='qualified'>
+
+	<import namespace='http://www.w3.org/2000/09/xmldsig#'
+			schemaLocation='http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd'/>
+
+	<import namespace='http://www.w3.org/2001/04/xmlenc#'
+			schemaLocation='http://www.w3.org/TR/2002/REC-xmlenc-core-20021210/xenc-schema.xsd'/>
+
+	<element name="ConcatKDFParams" type="xenc11:ConcatKDFParamsType"/>
+	<complexType name="ConcatKDFParamsType">
+		<sequence>
+			<element ref="ds:DigestMethod"/>
+		</sequence>
+		<attribute name="AlgorithmID" type="hexBinary"/>
+		<attribute name="PartyUInfo" type="hexBinary"/>
+		<attribute name="PartyVInfo" type="hexBinary"/>
+		<attribute name="SuppPubInfo" type="hexBinary"/>
+		<attribute name="SuppPrivInfo" type="hexBinary"/>
+	</complexType>
+
+	<element name="DerivedKey" type="xenc11:DerivedKeyType"/>
+	<complexType name="DerivedKeyType">
+		<sequence>
+			<element ref="xenc11:KeyDerivationMethod" minOccurs="0"/>
+			<element ref="xenc:ReferenceList" minOccurs="0"/>
+			<element name="DerivedKeyName" type="string" minOccurs="0"/>
+			<element name="MasterKeyName" type="string" minOccurs="0"/>
+		</sequence>
+		<attribute name="Recipient" type="string" use="optional"/>
+		<attribute name="Id" type="ID" use="optional"/>
+		<attribute name="Type" type="anyURI" use="optional"/>
+	</complexType>
+
+	<element name="KeyDerivationMethod" type="xenc11:KeyDerivationMethodType"/>
+	<complexType name="KeyDerivationMethodType">
+		<sequence>
+			<any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+		<attribute name="Algorithm" type="anyURI" use="required"/>
+	</complexType>
+
+	<element name="PBKDF2-params" type="xenc11:PBKDF2ParameterType"/>
+
+	<complexType name="AlgorithmIdentifierType">
+		<sequence>
+			<element name="Parameters" type="anyType" minOccurs="0"/>
+		</sequence>
+        <attribute name="Algorithm" type="anyURI" use="required" />
+	</complexType>
+
+	<complexType name="PRFAlgorithmIdentifierType">
+		<complexContent>
+          <restriction base="xenc11:AlgorithmIdentifierType">
+            <attribute name="Algorithm" type="anyURI" use="required" />
+          </restriction>
+        </complexContent>
+	</complexType>
+
+	<complexType name="PBKDF2ParameterType">
+		<sequence>
+			<element name="Salt">
+				<complexType>
+					<choice>
+						<element name="Specified" type="base64Binary"/>
+						<element name="OtherSource" type="xenc11:AlgorithmIdentifierType"/>
+					</choice>
+				</complexType>
+			</element>
+			<element name="IterationCount" type="positiveInteger"/>
+			<element name="KeyLength" type="positiveInteger"/>
+			<element name="PRF" type="xenc11:PRFAlgorithmIdentifierType"/>
+		</sequence>
+	</complexType>
+
+    <element name="MGF" type="xenc11:MGFType"/>
+    <complexType name="MGFType">
+      <complexContent>
+        <restriction base="xenc11:AlgorithmIdentifierType">
+          <attribute name="Algorithm" type="anyURI" use="required" />
+        </restriction>
+      </complexContent>
+    </complexType>
+
+</schema>

--- a/src/saml2/xml/schema/__init__.py
+++ b/src/saml2/xml/schema/__init__.py
@@ -23,6 +23,7 @@ def _create_xml_schema_validator(source=None, **kwargs):
     path_schema_xml = str(schema_resources.joinpath("xml.xsd"))
     path_schema_envelope = str(schema_resources.joinpath("envelope.xsd"))
     path_schema_xenc = str(schema_resources.joinpath("xenc-schema.xsd"))
+    path_schema_xenc_11 = str(schema_resources.joinpath("xenc-schema-11.xsd"))
     path_schema_xmldsig_core = str(schema_resources.joinpath("xmldsig-core-schema.xsd"))
     path_schema_saml_assertion = str(schema_resources.joinpath("saml-schema-assertion-2.0.xsd"))
     path_schema_saml_metadata = str(schema_resources.joinpath("saml-schema-metadata-2.0.xsd"))
@@ -39,6 +40,7 @@ def _create_xml_schema_validator(source=None, **kwargs):
         "http://www.w3.org/XML/1998/namespace": path_schema_xml,
         "http://schemas.xmlsoap.org/soap/envelope/": path_schema_envelope,
         "http://www.w3.org/2001/04/xmlenc#": path_schema_xenc,
+        "http://www.w3.org/2009/xmlenc11#": path_schema_xenc_11,
         "http://www.w3.org/2000/09/xmldsig#": path_schema_xmldsig_core,
         "urn:oasis:names:tc:SAML:2.0:assertion": path_schema_saml_assertion,
         "urn:oasis:names:tc:SAML:2.0:metadata": path_schema_saml_metadata,

--- a/tests/encrypted_attribute_statement.xml
+++ b/tests/encrypted_attribute_statement.xml
@@ -1,7 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ns0:AttributeStatement xmlns:ns0="urn:oasis:names:tc:SAML:2.0:assertion"
                         xmlns:ns1="http://www.w3.org/2001/04/xmlenc#"
-                        xmlns:ns2="http://www.w3.org/2000/09/xmldsig#">
+                        xmlns:ns2="http://www.w3.org/2000/09/xmldsig#"
+                        xmlns:ns3="http://www.w3.org/2009/xmlenc11#">
     <ns0:EncryptedAttribute >
         <ns1:EncryptedData Id="_dcf9eb6ed26d9332d940130e0cae1ba1"
                            Type="http://www.w3.org/2001/04/xmlenc#Element">
@@ -25,8 +26,9 @@
             </ns1:CipherData>
         </ns1:EncryptedData>
         <ns1:EncryptedKey Id="_1234">
-            <ns1:EncryptionMethod
-                    Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+            <ns1:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5">
+                <ns3:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha1" />
+            </ns1:EncryptionMethod>
             <ns2:KeyInfo>
                 <ns2:KeyName/>
             </ns2:KeyInfo>
@@ -48,8 +50,9 @@
                     Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
             <ns2:KeyInfo>
                 <ns1:EncryptedKey>
-                    <ns1:EncryptionMethod
-                            Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+                    <ns1:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5">
+                        <ns3:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha1" />
+                    </ns1:EncryptionMethod>
                     <ns2:KeyInfo>
                         <ns2:KeyName/>
                     </ns2:KeyInfo>
@@ -82,8 +85,9 @@
                     Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
             <ns2:KeyInfo>
                 <ns1:EncryptedKey>
-                    <ns1:EncryptionMethod
-                            Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+                    <ns1:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5">
+                        <ns3:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha1" />
+                    </ns1:EncryptionMethod>
                     <ns2:KeyInfo>
                         <ns2:KeyName/>
                     </ns2:KeyInfo>
@@ -116,8 +120,9 @@
                     Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
             <ns2:KeyInfo>
                 <ns1:EncryptedKey>
-                    <ns1:EncryptionMethod
-                            Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+                    <ns1:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5">
+                        <ns3:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha1" />
+                    </ns1:EncryptionMethod>
                     <ns2:KeyInfo>
                         <ns2:KeyName/>
                     </ns2:KeyInfo>


### PR DESCRIPTION
### Description
This adds XML Encryption 1.1 Schema to the schema validator.

##### The feature or problem addressed by this PR
Sweden Connect has recently added an MGF element with an algorithm in xmlenc11 to their responses. This PR starts addressing that change.

##### What your changes do and why you chose this solution
This change let's the schema validator handle an MGF element like this.
``` xml
<ns3:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p">
    <ns2:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
    <ns4:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha1" />
</ns3:EncryptionMethod>
```

### Checklist

* [X] Checked that no other issues or pull requests exist for the same issue/change
* [X] Added tests covering the new functionality
* [ ] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
