### PR TITLE
fix: prep_for_nego_auth: avoid double signing redirect requests

### DIFF
--- a/src/saml2/client.py
+++ b/src/saml2/client.py
@@ -144,8 +144,8 @@ class Saml2Client(Base):
             # XXX   ^through self.create_authn_request(...)
             # XXX - sign_redirect will add the signature to the query params
             # XXX   ^through self.apply_binding(...)
-            sign_redirect = sign and binding == BINDING_HTTP_REDIRECT
-            sign_post = sign and not sign_redirect
+            sign_redirect = sign if binding == BINDING_HTTP_REDIRECT else False
+            sign_post = sign if binding != BINDING_HTTP_REDIRECT else False
 
             reqid, request = self.create_authn_request(
                 destination=destination,


### PR DESCRIPTION
Fixes IdentityPython/pysaml2#819 (again)

The prepare_for_negotiated_authenticate method has sign parameter defaulting to None.

The logic setting `sign_redirect` and `sign_post` does not properly handle the three-state aspects that `sign` has with `None` mixed with `True` and `False`.

Python evalutes `None and <any value>` as `None`, so as a result, `None` gets passed for both `sign_redirect` and `sign_post`.

However, `None` is interpreted by `Entity._message` as "sign `if self.should_sign`".

As a result, for Redirect binding, the authentication request gets signed both in XML and in HTTP parameter (recurrence of IdentityPython/pysaml2#819).

Fix this by passing an explicit `False` for exactly one of the branches (sign_post for REDIRECT binding and sign_redirect for all other bindings), passing through value of `sign` for the other branch.

### Description

##### The feature or problem addressed by this PR

Fix double signing of of Authentication requests with redirect binding.

##### What your changes do and why you chose this solution

Fix logic to avoid passing `None` for both `sign_post` and `sign_redirect` (as they both get interpreted as "sign if `should_sign`)

### Checklist

* [X] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [X] Updated documentation OR the change is too minor to be documented
* [X] Updated CHANGELOG.md OR changes are insignificant
