### PR TITLE
feat: bump pyopenssl 24.3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ defusedxml = "*"
 importlib-metadata = {version = ">=1.7.0", python = "<3.8"}
 importlib-resources = {python = "<3.9", version = "*"}
 paste = {optional = true, version = "*"}
-pyopenssl = "<24.3.0"
+pyopenssl = "<24.4.0"
 python-dateutil = "*"
 pytz = "*"
 "repoze.who" = {optional = true, version = "*"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ defusedxml = "*"
 importlib-metadata = {version = ">=1.7.0", python = "<3.8"}
 importlib-resources = {python = "<3.9", version = "*"}
 paste = {optional = true, version = "*"}
-pyopenssl = "<24.4.0"
+pyopenssl = "<25.2.0"
 python-dateutil = "*"
 pytz = "*"
 "repoze.who" = {optional = true, version = "*"}


### PR DESCRIPTION


### Description
This PR upgrade pyopenssl dependency to address security alert.

##### The feature or problem addressed by this PR

This PR is for addressing security alert `GHSA-79v4-65xg-pq4g`.

https://github.com/advisories/GHSA-79v4-65xg-pq4g


##### What your changes do and why you chose this solution

 Current constraints is `<24.3.0`(up to 24.2.x). New constratints is `<24.4.0`(up to 24.3.x). 

### Checklist

* [x] Checked that no other issues or pull requests exist for the same issue/change
* [-] Added tests covering the new functionality
* [-] Updated documentation OR the change is too minor to be documented
* [] Updated CHANGELOG.md OR changes are insignificant



// I guess this constratints is for pyopenssl->cryptography migration.
https://github.com/IdentityPython/pysaml2/pull/977 https://github.com/IdentityPython/pysaml2/commit/735bfa5327f42080ef60e9fd31d8d31029d98e21