### PR TITLE
Improved documentation for signing/encryption keys.

### DIFF
--- a/docs/howto/config.rst
+++ b/docs/howto/config.rst
@@ -292,8 +292,8 @@ Example::
     key_file: "key.pem"
 
 *key_file* is the name of a PEM formatted file that contains the private key
-of the service. This is currently used both to encrypt/sign assertions and as
-the client key in an HTTPS session.
+of the service. This is currently used both to sign assertions and as
+the client key in an HTTPS (mutual TLS) session.
 
 cert_file
 ^^^^^^^^^
@@ -324,7 +324,14 @@ Example::
 encryption_keypairs
 ^^^^^^^^^^^^^^^^^^^
 
-Indicates which certificates will be used for encryption capabilities::
+A list of dictionaries, each containing paths to the private and public keys
+used for encryption. The *key_file* refers to the PEM-formatted file that
+contains the private key for the service, while the *cert_file* refers to the
+corresponding public key (certificate) from the service's key pair. Both files
+must be in PEM format, and the *cert_file* should contain only a single
+certificate.
+
+Example::
 
     # Encryption
     'encryption_keypairs': [


### PR DESCRIPTION
These are improvements to the documentation regarding signing and encryption keys, related to the issue #985 . 

This is still **WIP** as I need to investigate how `tmp_cert_file` and `tmp_cert_key` are being used. I determined that this is the path where the keys are generated, but I am not sure what the generated keys are being used for.

I investigated `Entity`, `SecurityContext` and `CryptoBackend` to gather information on this, but someone can review this and see if I made a mistake.

Kind regards