### PR TITLE
do not assert both subject-id and pairwise-id

### DIFF
--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -1304,14 +1304,17 @@ class MetadataStore(MetaData):
             if entity_id in md_source:
                 return md_source.attribute_requirement(entity_id, index)
 
-    def subject_id_requirement(self, entity_id):
+    def subject_id_requirement_type(self, entity_id):
         try:
             entity_attributes = self.entity_attributes(entity_id)
         except KeyError:
-            return []
+            return ""
 
         subject_id_reqs = entity_attributes.get("urn:oasis:names:tc:SAML:profiles:subject-id:req") or []
-        subject_id_req = next(iter(subject_id_reqs), None)
+        return next(iter(subject_id_reqs), None)
+
+    def subject_id_requirement(self, entity_id):
+        subject_id_req = self.subject_id_requirement_type(entity_id)
         if subject_id_req == "any":
             return [
                 {

--- a/tests/test_37_entity_categories.py
+++ b/tests/test_37_entity_categories.py
@@ -400,3 +400,39 @@ def test_filter_ava_refeds_personalized_access():
     assert _eq(ava["eduPersonScopedAffiliation"], ["student@example.com"])
     assert _eq(ava["eduPersonAssurance"], ["http://www.swamid.se/policy/assurance/al1"])
     assert _eq(ava["schacHomeOrganization"], ["example.com"])
+
+
+def test_filter_subject_id_or_pairwise_id():
+    entity_id = "https://esi-coco.example.edu/saml2/metadata/"
+    mds = MetadataStore(ATTRCONV, sec_config, disable_ssl_certificate_validation=True)
+    mds.imp([{"class": "saml2.mdstore.MetaDataFile", "metadata": [(full_path("entity_esi_and_coco_sp.xml"),)]}])
+
+    policy_conf = {"default": {"lifetime": {"minutes": 15}, "entity_categories": ["swamid"]}}
+
+    policy = Policy(policy_conf, mds)
+
+    ava = {
+        "subject-id": ["subject-id"],
+        "pairwise-id": ["pairwise-id"],
+    }
+
+    required_attributes = [
+        {
+            "__class__": "urn:oasis:names:tc:SAML:2.0:metadata&RequestedAttribute",
+            "name": "urn:oasis:names:tc:SAML:attribute:pairwise-id",
+            "name_format": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+            "friendly_name": "pairwise-id",
+            "is_required": "true",
+        },
+        {
+            "__class__": "urn:oasis:names:tc:SAML:2.0:metadata&RequestedAttribute",
+            "name": "urn:oasis:names:tc:SAML:attribute:subject-id",
+            "name_format": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+            "friendly_name": "subject-id",
+            "is_required": "true",
+        },
+    ]
+
+    ava = policy.filter(ava, entity_id, required=required_attributes)
+
+    assert _eq(list(ava.keys()), ["pairwise-id"])


### PR DESCRIPTION
### Description

do not assert both subject-id and pairwise-id
default to pairwise-id if both are requested and available

##### The feature or problem addressed by this PR

When a SP requests subject-id any there pysaml2 will add both subject-id and pairwise-id to the list of required attributes which means that both will be released if they are available.

##### What your changes do and why you chose this solution

This PR will check if both subject-id and pairwise-id is in available attributes and default to only release pairwise-id if both are. This check only runs if the `urn:oasis:names:tc:SAML:profiles:subject-id:req` is set to `any`.


### Checklist

* [X] Checked that no other issues or pull requests exist for the same issue/change
* [X] Added tests covering the new functionality
* [ ] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
