### PR TITLE
Clarify units for accepted_time_diff config param

### DIFF
--- a/docs/howto/config.rst
+++ b/docs/howto/config.rst
@@ -522,7 +522,7 @@ accepted_time_diff
 
 If your computer and another computer that you are communicating with are not
 in sync regarding the computer clock, then here you can state how big a
-difference you are prepared to accept.
+difference in seconds you are prepared to accept.
 
 .. note:: This will indiscriminately affect all time comparisons.
     Hence your server may accept a statement that in fact is too old.


### PR DESCRIPTION

### Description

##### The feature or problem addressed by this PR

The `accepted_time_diff` param is taken as seconds diff, but this isn't clear from the docs without digging in the source code.


##### What your changes do and why you chose this solution

Update the docs

### Checklist

* [N/A] Checked that no other issues or pull requests exist for the same issue/change
* [N/A] Added tests covering the new functionality
* [x] Updated documentation ~~OR the change is too minor to be documented~~
* [x] ~~Updated CHANGELOG.md OR~~ changes are insignificant
