### PR TITLE
Schema validation fails on SAML responses with QName-typed AttributeV…

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -1398,16 +1398,23 @@ class SecurityContext:
 
         try:
             validate_doc_with_schema(str(item))
-        except XMLSchemaError as e:
-            error_context = {
-                "message": "Signature verification failed. Invalid document format.",
-                "reason": str(e),
-                "ID": item.id,
-                "issuer": _issuer,
-                "type": node_name,
-                "document": decoded_xml,
-            }
-            raise SignatureError(error_context) from e
+        except XMLSchemaError:
+            # ElementTree round-trips can lose namespace declarations needed
+            # for QName attribute values (e.g. xsi:type="tn:boolean"), making
+            # the re-serialized XML fail schema validation even when the
+            # original document is valid. Fall back to the original XML.
+            try:
+                validate_doc_with_schema(decoded_xml)
+            except XMLSchemaError as e:
+                error_context = {
+                    "message": "Signature verification failed. Invalid document format.",
+                    "reason": str(e),
+                    "ID": item.id,
+                    "issuer": _issuer,
+                    "type": node_name,
+                    "document": decoded_xml,
+                }
+                raise SignatureError(error_context) from e
 
         # saml-core section "5.4 XML Signature Profile" defines constrains on the
         # xmldsig-core facilities. It explicitly dictates that enveloped signatures


### PR DESCRIPTION
### Description

##### The feature or problem addressed by this PR

SAML responses from IdPs that include typed `AttributeValue` elements fail signature verification with:

```
Signature verification failed. Invalid document format.
```

and a reason like:

```
global component 'tn:boolean' not found
```

This affects any SAML response containing `AttributeValue` elements with `xsi:type` using a locally-declared namespace prefix, such as:

```xml
<AttributeValue a:type="tn:boolean"
    xmlns:tn="http://www.w3.org/2001/XMLSchema"
    xmlns:a="http://www.w3.org/2001/XMLSchema-instance">true</AttributeValue>
```

This is valid XML — the namespace prefixes are properly declared. However, pysaml2 rejects it because `_check_signature` validates `str(item)` (the re-serialized XML after an ElementTree round-trip), and the round-trip drops namespace declarations that are only referenced inside attribute **values** (QNames).

The issue is that Python's `xml.etree.ElementTree` is not QName-aware for attribute values:

1. `ElementTree.fromstring()` resolves the attribute *key* `a:type` into `{http://www.w3.org/2001/XMLSchema-instance}type` correctly
2. But the attribute *value* `tn:boolean` is stored as an opaque string
3. `xmlns:tn="http://www.w3.org/2001/XMLSchema"` is consumed by the parser and not preserved
4. `str(item)` re-serializes the object with `xsi:type="tn:boolean"` but no `xmlns:tn` declaration
5. `xmlschema` tries to resolve `tn:boolean` as a QName, cannot find the `tn` prefix, and raises a validation error

A real-world examle response that triggers this contains claims like:

```xml
<Attribute Name="http://schemas.microsoft.com/2012/01/devicecontext/claims/isregistereduser">
  <AttributeValue a:type="tn:boolean"
      xmlns:tn="http://www.w3.org/2001/XMLSchema"
      xmlns:a="http://www.w3.org/2001/XMLSchema-instance">true</AttributeValue>
</Attribute>
```

Reproduction script:

```python
import xml.etree.ElementTree as ET
from xmlschema import XMLSchema

original = (
    '<AttributeValue '
    'xmlns:a="http://www.w3.org/2001/XMLSchema-instance" '
    'xmlns:tn="http://www.w3.org/2001/XMLSchema" '
    'a:type="tn:boolean">true</AttributeValue>'
)

elem = ET.fromstring(original)
roundtripped = ET.tostring(elem, encoding='unicode')

print("Original:    ", original)
print("Round-tripped:", roundtripped)
# Round-tripped: <AttributeValue xmlns:xsi="..." xsi:type="tn:boolean">true</AttributeValue>
# Note: xmlns:tn declaration is GONE

schema = XMLSchema(
    '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">'
    '<xs:element name="AttributeValue" type="xs:anyType" nillable="true"/>'
    '</xs:schema>'
)

schema.validate(original)       # PASSES
schema.validate(roundtripped)   # FAILS: "global component 'tn:boolean' not found"
```

##### What your changes do and why you chose this solution

When `str(item)` fails schema validation in `_check_signature`, the fix falls back to validating `decoded_xml` — the original XML document before the parse/serialize round-trip. If the original also fails validation, the error is raised as before.

The fallback approach was chosen over always validating `decoded_xml` because `decoded_xml` is not always the original wire-format XML. In some code paths (e.g. encrypted assertions), it is a pysaml2-reconstructed XML that may itself have serialization quirks. The fallback ensures both cases work:

- **Normal responses:** `str(item)` fails due to lost namespace prefixes → fallback to `decoded_xml` (original wire XML) succeeds
- **Encrypted assertions:** `str(item)` succeeds → no fallback needed

This is safe because:

- Schema validation still happens — the original wire-format XML is validated against the same SAML schema
- The original XML is what the IdP signed and what the cryptographic signature covers
- The `verify_signature` call later in the method already uses `decoded_xml`
- All existing behavior is preserved — the fallback only triggers when `str(item)` fails

### relevant issues

- https://github.com/IdentityPython/pysaml2/issues/921

### Checklist

* [x] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [x] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
