### PR TITLE
Use isinstance instead of type is for config

### DIFF
--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -1114,7 +1114,7 @@ class MetadataStore(MetaData):
 
     def imp(self, spec):
         # This serves as a backwards compatibility
-        if type(spec) is dict:
+        if isinstance(spec, dict):
             # Old style...
             for key, vals in spec.items():
                 for val in vals:


### PR DESCRIPTION
In Django you can use special settings drivers that may represent dicts as a subclass of pythons 'dict'. In this case leading to crash while parsing the metadata section of the config.

### Description

##### The feature or problem addressed by this PR

<!-- an explanation of the issue that is being resolved with this PR -->
<!-- or, an explanation of the feature that is being added with this PR -->
<!-- or, link to an issue describing the problem -->


##### What your changes do and why you chose this solution

It changes the check for an identical `dict` type to also match all subclasses.
The change appears pretty straight forward to me, and allows pysaml2 to be used in combination with e.g. DynaConf.
I might need a pointer for a good strategy to test this.

### Checklist

* [x] Checked that no other issues or pull requests exist for the same issue/change
* [ ] Added tests covering the new functionality
* [ ] Updated documentation OR the change is too minor to be documented
* [ ] Updated CHANGELOG.md OR changes are insignificant
