### PR TITLE
Use cryptography's non-deprecated CFB location when available

### DIFF
--- a/src/saml2/cryptography/symmetric.py
+++ b/src/saml2/cryptography/symmetric.py
@@ -15,6 +15,14 @@ import cryptography.hazmat.primitives.ciphers as _ciphers
 from .errors import SymmetricCryptographyError
 
 
+try:
+    # cryptography >= 47 moved CFB here; use it to avoid CryptographyDeprecationWarning.
+    from cryptography.hazmat.decrepit.ciphers.modes import CFB as _CFB
+except ImportError:
+    # older cryptography versions don't have the "decrepit" module yet.
+    _CFB = _ciphers.modes.CFB
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -105,7 +113,7 @@ class AESCipher:
 
     POSTFIX_MODE = {
         "cbc": _ciphers.modes.CBC,
-        "cfb": _ciphers.modes.CFB,
+        "cfb": _CFB,
     }
 
     AES_BLOCK_SIZE = int(_ciphers.algorithms.AES.block_size / 8)


### PR DESCRIPTION
Fixes #1033.

CFB moved from cryptography.hazmat.primitives.ciphers.modes to cryptography.hazmat.decrepit.ciphers.modes in cryptography 47, which is also exactly when the old location started emitting CryptographyDeprecationWarning on attribute access.

This prefers the new location when it exists, falling back to the old one on cryptography < 47 where decrepit does not exist yet. That removes the warning both at import time and when AESCipher is actually used with cfb mode, for every supported cryptography version.

All 7 existing tests in test_92_aes.py pass unchanged, tested against cryptography 43.0.3 and 49.0.0.